### PR TITLE
refactoring of Eynollah init and model loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,14 @@ deps-test: models_eynollah
 
 smoke-test: TMPDIR != mktemp -d
 smoke-test: tests/resources/kant_aufklaerung_1784_0020.tif
+	# layout analysis:
 	eynollah layout -i $< -o $(TMPDIR) -m $(CURDIR)/models_eynollah
 	fgrep -q http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 $(TMPDIR)/$(basename $(<F)).xml
 	fgrep -c -e TextRegion -e ImageRegion -e SeparatorRegion $(TMPDIR)/$(basename $(<F)).xml
+	# directory mode (skip one, add one):
+	eynollah layout -di $(<D) -o $(TMPDIR) -m $(CURDIR)/models_eynollah
+	test -s $(TMPDIR)/euler_rechenkunst01_1738_0025.xml
+	# binarize:
 	eynollah binarization -m $(CURDIR)/default-2021-03-09 $< $(TMPDIR)/$(<F)
 	test -s $(TMPDIR)/$(<F)
 	@set -x; test "$$(identify -format '%w %h' $<)" = "$$(identify -format '%w %h' $(TMPDIR)/$(<F))"

--- a/README.md
+++ b/README.md
@@ -83,23 +83,27 @@ If no option is set, the tool performs layout detection of main regions (backgro
 The best output quality is produced when RGB images are used as input rather than greyscale or binarized images.
 
 #### Use as OCR-D processor
-🚧 **Work in progress** 
 
-Eynollah ships with a CLI interface to be used as [OCR-D](https://ocr-d.de) processor. 
+Eynollah ships with a CLI interface to be used as [OCR-D](https://ocr-d.de) [processor](https://ocr-d.de/en/spec/cli).
 
 In this case, the source image file group with (preferably) RGB images should be used as input like this:
 
-```
-ocrd-eynollah-segment -I OCR-D-IMG -O SEG-LINE -P models
-```
-    
-Any image referenced by `@imageFilename` in PAGE-XML is passed on directly to Eynollah as a processor, so that e.g.
+    ocrd-eynollah-segment -I OCR-D-IMG -O OCR-D-SEG -P models 2022-04-05
 
-```
-ocrd-eynollah-segment -I OCR-D-IMG-BIN -O SEG-LINE -P models
-```
-    
-uses the original (RGB) image despite any binarization that may have occured in previous OCR-D processing steps
+
+If the input file group is PAGE-XML (from a previous OCR-D workflow step), Eynollah behaves as follows:
+- existing regions are kept and ignored (i.e. in effect they might overlap segments from Eynollah results)
+- existing annotation (and respective `AlternativeImage`s) are partially _ignored_:
+  - previous page frame detection (`cropped` images)
+  - previous derotation (`deskewed` images)
+  - previous thresholding (`binarized` images)
+- if the page-level image nevertheless deviates from the original (`@imageFilename`)
+  (because some other preprocessing step was in effect like `denoised`), then
+  the output PAGE-XML will be based on that as new top-level (`@imageFilename`)
+
+    ocrd-eynollah-segment -I OCR-D-XYZ -O OCR-D-SEG -P models 2022-04-05
+
+Still, in general, it makes more sense to add other workflow steps **after** Eynollah.
 
 #### Additional documentation
 Please check the [wiki](https://github.com/qurator-spk/eynollah/wiki).

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ If the input file group is PAGE-XML (from a previous OCR-D workflow step), Eynol
   (because some other preprocessing step was in effect like `denoised`), then
   the output PAGE-XML will be based on that as new top-level (`@imageFilename`)
 
+
     ocrd-eynollah-segment -I OCR-D-XYZ -O OCR-D-SEG -P models 2022-04-05
 
 Still, in general, it makes more sense to add other workflow steps **after** Eynollah.

--- a/src/eynollah/cli.py
+++ b/src/eynollah/cli.py
@@ -314,8 +314,7 @@ def layout(image, out, overwrite, dir_in, model, save_images, save_layout, save_
     if dir_in:
         eynollah.run(dir_in=dir_in, overwrite=overwrite)
     else:
-        pcgts = eynollah.run(image_filename=image)
-        eynollah.writer.write_pagexml(pcgts)
+        eynollah.run(image_filename=image)
 
 
 @main.command()

--- a/src/eynollah/cli.py
+++ b/src/eynollah/cli.py
@@ -256,19 +256,33 @@ def layout(image, out, overwrite, dir_in, model, save_images, save_layout, save_
     if log_level:
         getLogger('eynollah').setLevel(getLevelName(log_level))
     if not enable_plotting and (save_layout or save_deskewed or save_all or save_page or save_images or allow_enhancement):
-        print("Error: You used one of -sl, -sd, -sa, -sp, -si or -ae but did not enable plotting with -ep")
-        sys.exit(1)
+        raise ValueError("Plotting with -sl, -sd, -sa, -sp, -si or -ae also requires -ep")
     elif enable_plotting and not (save_layout or save_deskewed or save_all or save_page or save_images or allow_enhancement):
-        print("Error: You used -ep to enable plotting but set none of -sl, -sd, -sa, -sp, -si or -ae")
-        sys.exit(1)
+        raise ValueError("Plotting with -ep also requires -sl, -sd, -sa, -sp, -si or -ae")
     if textline_light and not light_version:
-        print('Error: You used -tll to enable light textline detection but -light is not enabled')
-        sys.exit(1)
+        raise ValueError("Light textline detection with -tll also requires -light")
     if light_version and not textline_light:
-        print('Error: You used -light without -tll. Light version need light textline to be enabled.')
-    if extract_only_images and  (allow_enhancement or allow_scaling or light_version or curved_line or textline_light or full_layout or tables or right2left or headers_off) :
-        print('Error: You used -eoi which can not be enabled alongside light_version -light or allow_scaling -as or allow_enhancement -ae or curved_line -cl or textline_light -tll or full_layout -fl or tables -tab or right2left -r2l or headers_off -ho')
-        sys.exit(1)
+        raise ValueError("Light version with -light also requires light textline detection -tll")
+    if extract_only_images and allow_enhancement:
+        raise ValueError("Image extraction with -eoi can not be enabled alongside allow_enhancement -ae")
+    if extract_only_images and allow_scaling:
+        raise ValueError("Image extraction with -eoi can not be enabled alongside allow_scaling -as")
+    if extract_only_images and light_version:
+        raise ValueError("Image extraction with -eoi can not be enabled alongside light_version -light")
+    if extract_only_images and curved_line:
+        raise ValueError("Image extraction with -eoi can not be enabled alongside curved_line -cl")
+    if extract_only_images and textline_light:
+        raise ValueError("Image extraction with -eoi can not be enabled alongside textline_light -tll")
+    if extract_only_images and full_layout:
+        raise ValueError("Image extraction with -eoi can not be enabled alongside full_layout -fl")
+    if extract_only_images and tables:
+        raise ValueError("Image extraction with -eoi can not be enabled alongside tables -tab")
+    if extract_only_images and right2left:
+        raise ValueError("Image extraction with -eoi can not be enabled alongside right2left -r2l")
+    if extract_only_images and headers_off:
+        raise ValueError("Image extraction with -eoi can not be enabled alongside headers_off -ho")
+    if image is None and dir_in is None:
+        raise ValueError("Either a single image -i or a dir_in -di is required")
     eynollah = Eynollah(
         model,
         logger=getLogger('Eynollah'),

--- a/src/eynollah/cli.py
+++ b/src/eynollah/cli.py
@@ -285,7 +285,7 @@ def layout(image, out, overwrite, dir_in, model, save_images, save_layout, save_
         raise ValueError("Either a single image -i or a dir_in -di is required")
     eynollah = Eynollah(
         model,
-        logger=getLogger('Eynollah'),
+        logger=getLogger('eynollah'),
         dir_out=out,
         dir_of_cropped_images=save_images,
         extract_only_images=extract_only_images,

--- a/src/eynollah/cli.py
+++ b/src/eynollah/cli.py
@@ -272,10 +272,7 @@ def layout(image, out, overwrite, dir_in, model, save_images, save_layout, save_
     eynollah = Eynollah(
         model,
         logger=getLogger('Eynollah'),
-        image_filename=image,
-        overwrite=overwrite,
         dir_out=out,
-        dir_in=dir_in,
         dir_of_cropped_images=save_images,
         extract_only_images=extract_only_images,
         dir_of_layout=save_layout,
@@ -301,9 +298,9 @@ def layout(image, out, overwrite, dir_in, model, save_images, save_layout, save_
         skip_layout_and_reading_order=skip_layout_and_reading_order,
     )
     if dir_in:
-        eynollah.run()
+        eynollah.run(dir_in=dir_in, overwrite=overwrite)
     else:
-        pcgts = eynollah.run()
+        pcgts = eynollah.run(image_filename=image)
         eynollah.writer.write_pagexml(pcgts)
 
 

--- a/src/eynollah/cli.py
+++ b/src/eynollah/cli.py
@@ -314,7 +314,7 @@ def layout(image, out, overwrite, dir_in, model, save_images, save_layout, save_
     if dir_in:
         eynollah.run(dir_in=dir_in, overwrite=overwrite)
     else:
-        eynollah.run(image_filename=image)
+        eynollah.run(image_filename=image, overwrite=overwrite)
 
 
 @main.command()

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -257,7 +257,6 @@ class Eynollah:
             self.num_col_lower = int(num_col_lower)
         else:
             self.num_col_lower = num_col_lower
-        self.pcgts = pcgts
         if not dir_in:
             self.plotter = None if not enable_plotting else EynollahPlotter(
                 dir_out=self.dir_out,
@@ -407,8 +406,7 @@ class Eynollah:
             dir_out=self.dir_out,
             image_filename=self.image_filename,
             curved_line=self.curved_line,
-            textline_light = self.textline_light,
-            pcgts=self.pcgts)
+            textline_light = self.textline_light)
 
     def imread(self, grayscale=False, uint8=True):
         key = 'img'

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -32,7 +32,7 @@ from scipy.ndimage import gaussian_filter1d
 from numba import cuda
 
 from ocrd import OcrdPage
-from ocrd_utils import getLogger
+from ocrd_utils import getLogger, tf_disable_interactive_logs
 
 try:
     import torch
@@ -47,14 +47,11 @@ try:
 except ImportError:
     TrOCRProcessor = VisionEncoderDecoderModel = None
 
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 #os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
-stderr = sys.stderr
-sys.stderr = open(os.devnull, "w")
+tf_disable_interactive_logs()
 import tensorflow as tf
 from tensorflow.python.keras import backend as K
 from tensorflow.keras.models import load_model
-sys.stderr = stderr
 tf.get_logger().setLevel("ERROR")
 warnings.filterwarnings("ignore")
 # use tf1 compatibility for keras backend
@@ -3614,7 +3611,7 @@ class Eynollah:
             for ij in range(len(all_found_textline_polygons[j])):
                 con_ind = all_found_textline_polygons[j][ij]
                 area = cv2.contourArea(con_ind)
-                con_ind = con_ind.astype(np.float)
+                con_ind = con_ind.astype(float)
                 
                 x_differential = np.diff( con_ind[:,0,0])
                 y_differential = np.diff( con_ind[:,0,1])
@@ -3718,7 +3715,7 @@ class Eynollah:
             con_ind = all_found_textline_polygons[j]
             #print(len(con_ind[:,0,0]),'con_ind[:,0,0]')
             area = cv2.contourArea(con_ind)
-            con_ind = con_ind.astype(np.float)
+            con_ind = con_ind.astype(float)
             
             x_differential = np.diff( con_ind[:,0,0])
             y_differential = np.diff( con_ind[:,0,1])
@@ -3821,7 +3818,7 @@ class Eynollah:
                 con_ind = all_found_textline_polygons[j][ij]
                 area = cv2.contourArea(con_ind)
                 
-                con_ind = con_ind.astype(np.float)
+                con_ind = con_ind.astype(float)
                 
                 x_differential = np.diff( con_ind[:,0,0])
                 y_differential = np.diff( con_ind[:,0,1])
@@ -4053,7 +4050,7 @@ class Eynollah:
         for j in range(len(all_found_textline_polygons)):
             for i in range(len(all_found_textline_polygons[j])):
                 con_ind = all_found_textline_polygons[j][i]
-                con_ind = con_ind.astype(np.float)
+                con_ind = con_ind.astype(float)
                 
                 x_differential = np.diff( con_ind[:,0,0])
                 y_differential = np.diff( con_ind[:,0,1])

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4233,571 +4233,568 @@ class Eynollah:
             print("all Job done in %.1fs", time.time() - t0_tot)
 
     def run_single(self):
-        # conditional merely for indentation (= smaller diff)
-        if True:
-            t0 = time.time()
-            img_res, is_image_enhanced, num_col_classifier, num_column_is_classified = self.run_enhancement(self.light_version)
-            self.logger.info("Enhancing took %.1fs ", time.time() - t0)
-            if self.extract_only_images:
-                text_regions_p_1, erosion_hurts, polygons_lines_xml, polygons_of_images, image_page, page_coord, cont_page = \
-                    self.get_regions_light_v_extract_only_images(img_res, is_image_enhanced, num_col_classifier)
-                ocr_all_textlines = None
-                pcgts = self.writer.build_pagexml_no_full_layout(
-                    [], page_coord, [], [], [], [],
-                    polygons_of_images, [], [], [], [], [],
-                    cont_page, [], [], ocr_all_textlines)
-                if self.plotter:
-                    self.plotter.write_images_into_directory(polygons_of_images, image_page)
-                return pcgts
+        t0 = time.time()
+        img_res, is_image_enhanced, num_col_classifier, num_column_is_classified = self.run_enhancement(self.light_version)
+        self.logger.info("Enhancing took %.1fs ", time.time() - t0)
+        if self.extract_only_images:
+            text_regions_p_1, erosion_hurts, polygons_lines_xml, polygons_of_images, image_page, page_coord, cont_page = \
+                self.get_regions_light_v_extract_only_images(img_res, is_image_enhanced, num_col_classifier)
+            ocr_all_textlines = None
+            pcgts = self.writer.build_pagexml_no_full_layout(
+                [], page_coord, [], [], [], [],
+                polygons_of_images, [], [], [], [], [],
+                cont_page, [], [], ocr_all_textlines)
+            if self.plotter:
+                self.plotter.write_images_into_directory(polygons_of_images, image_page)
+            return pcgts
 
-            if self.skip_layout_and_reading_order:
-                _ ,_, _, textline_mask_tot_ea, img_bin_light = \
-                    self.get_regions_light_v(img_res, is_image_enhanced, num_col_classifier,
-                                             skip_layout_and_reading_order=self.skip_layout_and_reading_order)
+        if self.skip_layout_and_reading_order:
+            _ ,_, _, textline_mask_tot_ea, img_bin_light = \
+                self.get_regions_light_v(img_res, is_image_enhanced, num_col_classifier,
+                                         skip_layout_and_reading_order=self.skip_layout_and_reading_order)
 
-                page_coord, image_page, textline_mask_tot_ea, img_bin_light, cont_page = \
-                    self.run_graphics_and_columns_without_layout(textline_mask_tot_ea, img_bin_light)
+            page_coord, image_page, textline_mask_tot_ea, img_bin_light, cont_page = \
+                self.run_graphics_and_columns_without_layout(textline_mask_tot_ea, img_bin_light)
 
 
-                ##all_found_textline_polygons =self.scale_contours_new(textline_mask_tot_ea)
+            ##all_found_textline_polygons =self.scale_contours_new(textline_mask_tot_ea)
 
-                cnt_clean_rot_raw, hir_on_cnt_clean_rot = return_contours_of_image(textline_mask_tot_ea)
-                all_found_textline_polygons = filter_contours_area_of_image(
-                    textline_mask_tot_ea, cnt_clean_rot_raw, hir_on_cnt_clean_rot, max_area=1, min_area=0.00001)
+            cnt_clean_rot_raw, hir_on_cnt_clean_rot = return_contours_of_image(textline_mask_tot_ea)
+            all_found_textline_polygons = filter_contours_area_of_image(
+                textline_mask_tot_ea, cnt_clean_rot_raw, hir_on_cnt_clean_rot, max_area=1, min_area=0.00001)
 
-                all_found_textline_polygons=[ all_found_textline_polygons ]
+            all_found_textline_polygons=[ all_found_textline_polygons ]
 
-                all_found_textline_polygons = self.dilate_textregions_contours_textline_version(
-                    all_found_textline_polygons)
-                all_found_textline_polygons = self.filter_contours_inside_a_bigger_one(
-                    all_found_textline_polygons, textline_mask_tot_ea, type_contour="textline")
+            all_found_textline_polygons = self.dilate_textregions_contours_textline_version(
+                all_found_textline_polygons)
+            all_found_textline_polygons = self.filter_contours_inside_a_bigger_one(
+                all_found_textline_polygons, textline_mask_tot_ea, type_contour="textline")
 
 
-                order_text_new = [0]
-                slopes =[0]
-                id_of_texts_tot =['region_0001']
+            order_text_new = [0]
+            slopes =[0]
+            id_of_texts_tot =['region_0001']
 
-                polygons_of_images = []
-                slopes_marginals = []
-                polygons_of_marginals = []
-                all_found_textline_polygons_marginals = []
-                all_box_coord_marginals = []
-                polygons_lines_xml = []
-                contours_tables = []
-                ocr_all_textlines = None
-                pcgts = self.writer.build_pagexml_no_full_layout(
-                    cont_page, page_coord, order_text_new, id_of_texts_tot,
-                    all_found_textline_polygons, page_coord, polygons_of_images, polygons_of_marginals,
-                    all_found_textline_polygons_marginals, all_box_coord_marginals, slopes, slopes_marginals,
-                    cont_page, polygons_lines_xml, contours_tables, ocr_all_textlines)
-                return pcgts
+            polygons_of_images = []
+            slopes_marginals = []
+            polygons_of_marginals = []
+            all_found_textline_polygons_marginals = []
+            all_box_coord_marginals = []
+            polygons_lines_xml = []
+            contours_tables = []
+            ocr_all_textlines = None
+            pcgts = self.writer.build_pagexml_no_full_layout(
+                cont_page, page_coord, order_text_new, id_of_texts_tot,
+                all_found_textline_polygons, page_coord, polygons_of_images, polygons_of_marginals,
+                all_found_textline_polygons_marginals, all_box_coord_marginals, slopes, slopes_marginals,
+                cont_page, polygons_lines_xml, contours_tables, ocr_all_textlines)
+            return pcgts
 
-            #print("text region early -1 in %.1fs", time.time() - t0)
-            t1 = time.time()
-            if self.light_version:
-                text_regions_p_1 ,erosion_hurts, polygons_lines_xml, textline_mask_tot_ea, img_bin_light = \
-                    self.get_regions_light_v(img_res, is_image_enhanced, num_col_classifier)
-                #print("text region early -2 in %.1fs", time.time() - t0)
+        #print("text region early -1 in %.1fs", time.time() - t0)
+        t1 = time.time()
+        if self.light_version:
+            text_regions_p_1 ,erosion_hurts, polygons_lines_xml, textline_mask_tot_ea, img_bin_light = \
+                self.get_regions_light_v(img_res, is_image_enhanced, num_col_classifier)
+            #print("text region early -2 in %.1fs", time.time() - t0)
 
-                if num_col_classifier == 1 or num_col_classifier ==2:
-                    if num_col_classifier == 1:
-                        img_w_new = 1000
-                    else:
-                        img_w_new = 1300
-                    img_h_new = img_w_new * textline_mask_tot_ea.shape[0] // textline_mask_tot_ea.shape[1]
-
-                    textline_mask_tot_ea_deskew = resize_image(textline_mask_tot_ea,img_h_new, img_w_new )
-
-                    slope_deskew, slope_first = self.run_deskew(textline_mask_tot_ea_deskew)
-                else:
-                    slope_deskew, slope_first = self.run_deskew(textline_mask_tot_ea)
-                #print("text region early -2,5 in %.1fs", time.time() - t0)
-                #self.logger.info("Textregion detection took %.1fs ", time.time() - t1t)
-                num_col, num_col_classifier, img_only_regions, page_coord, image_page, mask_images, mask_lines, \
-                    text_regions_p_1, cont_page, table_prediction, textline_mask_tot_ea, img_bin_light = \
-                        self.run_graphics_and_columns_light(text_regions_p_1, textline_mask_tot_ea,
-                                                            num_col_classifier, num_column_is_classified, erosion_hurts, img_bin_light)
-                #self.logger.info("run graphics %.1fs ", time.time() - t1t)
-                #print("text region early -3 in %.1fs", time.time() - t0)
-                textline_mask_tot_ea_org = np.copy(textline_mask_tot_ea)
-                #print("text region early -4 in %.1fs", time.time() - t0)
-            else:
-                text_regions_p_1 ,erosion_hurts, polygons_lines_xml = \
-                    self.get_regions_from_xy_2models(img_res, is_image_enhanced,
-                                                     num_col_classifier)
-                self.logger.info("Textregion detection took %.1fs ", time.time() - t1)
-
-                t1 = time.time()
-                num_col, num_col_classifier, img_only_regions, page_coord, image_page, mask_images, mask_lines, \
-                    text_regions_p_1, cont_page, table_prediction = \
-                        self.run_graphics_and_columns(text_regions_p_1, num_col_classifier, num_column_is_classified, erosion_hurts)
-                self.logger.info("Graphics detection took %.1fs ", time.time() - t1)
-                #self.logger.info('cont_page %s', cont_page)
-            #plt.imshow(table_prediction)
-            #plt.show()
-
-            if not num_col:
-                self.logger.info("No columns detected, outputting an empty PAGE-XML")
-                ocr_all_textlines = None
-                pcgts = self.writer.build_pagexml_no_full_layout(
-                    [], page_coord, [], [], [], [], [], [], [], [], [], [],
-                    cont_page, [], [], ocr_all_textlines)
-                return pcgts
-
-            #print("text region early in %.1fs", time.time() - t0)
-            t1 = time.time()
-            if not self.light_version:
-                textline_mask_tot_ea = self.run_textline(image_page)
-                self.logger.info("textline detection took %.1fs", time.time() - t1)
-                t1 = time.time()
-                slope_deskew, slope_first = self.run_deskew(textline_mask_tot_ea)
-                self.logger.info("deskewing took %.1fs", time.time() - t1)
-            elif num_col_classifier in (1,2):
-                org_h_l_m = textline_mask_tot_ea.shape[0]
-                org_w_l_m = textline_mask_tot_ea.shape[1]
+            if num_col_classifier == 1 or num_col_classifier ==2:
                 if num_col_classifier == 1:
-                    img_w_new = 2000
+                    img_w_new = 1000
                 else:
-                    img_w_new = 2400
+                    img_w_new = 1300
                 img_h_new = img_w_new * textline_mask_tot_ea.shape[0] // textline_mask_tot_ea.shape[1]
 
-                image_page = resize_image(image_page,img_h_new, img_w_new )
-                textline_mask_tot_ea = resize_image(textline_mask_tot_ea,img_h_new, img_w_new )
-                mask_images = resize_image(mask_images,img_h_new, img_w_new )
-                mask_lines = resize_image(mask_lines,img_h_new, img_w_new )
-                text_regions_p_1 = resize_image(text_regions_p_1,img_h_new, img_w_new )
-                table_prediction = resize_image(table_prediction,img_h_new, img_w_new )
+                textline_mask_tot_ea_deskew = resize_image(textline_mask_tot_ea,img_h_new, img_w_new )
 
-            textline_mask_tot, text_regions_p, image_page_rotated = \
-                self.run_marginals(image_page, textline_mask_tot_ea, mask_images, mask_lines,
-                                   num_col_classifier, slope_deskew, text_regions_p_1, table_prediction)
-
-            if self.light_version and num_col_classifier in (1,2):
-                image_page = resize_image(image_page,org_h_l_m, org_w_l_m )
-                textline_mask_tot_ea = resize_image(textline_mask_tot_ea,org_h_l_m, org_w_l_m )
-                text_regions_p = resize_image(text_regions_p,org_h_l_m, org_w_l_m )
-                textline_mask_tot = resize_image(textline_mask_tot,org_h_l_m, org_w_l_m )
-                text_regions_p_1 = resize_image(text_regions_p_1,org_h_l_m, org_w_l_m )
-                table_prediction = resize_image(table_prediction,org_h_l_m, org_w_l_m )
-                image_page_rotated = resize_image(image_page_rotated,org_h_l_m, org_w_l_m )
-
-            self.logger.info("detection of marginals took %.1fs", time.time() - t1)
-            #print("text region early 2 marginal in %.1fs", time.time() - t0)
-            ## birdan sora chock chakir
-            t1 = time.time()
-            if not self.full_layout:
-                polygons_of_images, img_revised_tab, text_regions_p_1_n, textline_mask_tot_d, regions_without_separators_d, \
-                    boxes, boxes_d, polygons_of_marginals, contours_tables = \
-                    self.run_boxes_no_full_layout(image_page, textline_mask_tot, text_regions_p, slope_deskew,
-                                                  num_col_classifier, table_prediction, erosion_hurts)
-                ###polygons_of_marginals = self.dilate_textregions_contours(polygons_of_marginals)
+                slope_deskew, slope_first = self.run_deskew(textline_mask_tot_ea_deskew)
             else:
-                polygons_of_images, img_revised_tab, text_regions_p_1_n, textline_mask_tot_d, regions_without_separators_d, \
-                    regions_fully, regions_without_separators, polygons_of_marginals, contours_tables = \
-                    self.run_boxes_full_layout(image_page, textline_mask_tot, text_regions_p, slope_deskew,
-                                               num_col_classifier, img_only_regions, table_prediction, erosion_hurts,
-                                               img_bin_light if self.light_version else None)
-                ###polygons_of_marginals = self.dilate_textregions_contours(polygons_of_marginals)
-                if self.light_version:
-                    drop_label_in_full_layout = 4
-                    textline_mask_tot_ea_org[img_revised_tab==drop_label_in_full_layout] = 0
+                slope_deskew, slope_first = self.run_deskew(textline_mask_tot_ea)
+            #print("text region early -2,5 in %.1fs", time.time() - t0)
+            #self.logger.info("Textregion detection took %.1fs ", time.time() - t1t)
+            num_col, num_col_classifier, img_only_regions, page_coord, image_page, mask_images, mask_lines, \
+                text_regions_p_1, cont_page, table_prediction, textline_mask_tot_ea, img_bin_light = \
+                    self.run_graphics_and_columns_light(text_regions_p_1, textline_mask_tot_ea,
+                                                        num_col_classifier, num_column_is_classified, erosion_hurts, img_bin_light)
+            #self.logger.info("run graphics %.1fs ", time.time() - t1t)
+            #print("text region early -3 in %.1fs", time.time() - t0)
+            textline_mask_tot_ea_org = np.copy(textline_mask_tot_ea)
+            #print("text region early -4 in %.1fs", time.time() - t0)
+        else:
+            text_regions_p_1 ,erosion_hurts, polygons_lines_xml = \
+                self.get_regions_from_xy_2models(img_res, is_image_enhanced,
+                                                 num_col_classifier)
+            self.logger.info("Textregion detection took %.1fs ", time.time() - t1)
+
+            t1 = time.time()
+            num_col, num_col_classifier, img_only_regions, page_coord, image_page, mask_images, mask_lines, \
+                text_regions_p_1, cont_page, table_prediction = \
+                    self.run_graphics_and_columns(text_regions_p_1, num_col_classifier, num_column_is_classified, erosion_hurts)
+            self.logger.info("Graphics detection took %.1fs ", time.time() - t1)
+            #self.logger.info('cont_page %s', cont_page)
+        #plt.imshow(table_prediction)
+        #plt.show()
+
+        if not num_col:
+            self.logger.info("No columns detected, outputting an empty PAGE-XML")
+            ocr_all_textlines = None
+            pcgts = self.writer.build_pagexml_no_full_layout(
+                [], page_coord, [], [], [], [], [], [], [], [], [], [],
+                cont_page, [], [], ocr_all_textlines)
+            return pcgts
+
+        #print("text region early in %.1fs", time.time() - t0)
+        t1 = time.time()
+        if not self.light_version:
+            textline_mask_tot_ea = self.run_textline(image_page)
+            self.logger.info("textline detection took %.1fs", time.time() - t1)
+            t1 = time.time()
+            slope_deskew, slope_first = self.run_deskew(textline_mask_tot_ea)
+            self.logger.info("deskewing took %.1fs", time.time() - t1)
+        elif num_col_classifier in (1,2):
+            org_h_l_m = textline_mask_tot_ea.shape[0]
+            org_w_l_m = textline_mask_tot_ea.shape[1]
+            if num_col_classifier == 1:
+                img_w_new = 2000
+            else:
+                img_w_new = 2400
+            img_h_new = img_w_new * textline_mask_tot_ea.shape[0] // textline_mask_tot_ea.shape[1]
+
+            image_page = resize_image(image_page,img_h_new, img_w_new )
+            textline_mask_tot_ea = resize_image(textline_mask_tot_ea,img_h_new, img_w_new )
+            mask_images = resize_image(mask_images,img_h_new, img_w_new )
+            mask_lines = resize_image(mask_lines,img_h_new, img_w_new )
+            text_regions_p_1 = resize_image(text_regions_p_1,img_h_new, img_w_new )
+            table_prediction = resize_image(table_prediction,img_h_new, img_w_new )
+
+        textline_mask_tot, text_regions_p, image_page_rotated = \
+            self.run_marginals(image_page, textline_mask_tot_ea, mask_images, mask_lines,
+                               num_col_classifier, slope_deskew, text_regions_p_1, table_prediction)
+
+        if self.light_version and num_col_classifier in (1,2):
+            image_page = resize_image(image_page,org_h_l_m, org_w_l_m )
+            textline_mask_tot_ea = resize_image(textline_mask_tot_ea,org_h_l_m, org_w_l_m )
+            text_regions_p = resize_image(text_regions_p,org_h_l_m, org_w_l_m )
+            textline_mask_tot = resize_image(textline_mask_tot,org_h_l_m, org_w_l_m )
+            text_regions_p_1 = resize_image(text_regions_p_1,org_h_l_m, org_w_l_m )
+            table_prediction = resize_image(table_prediction,org_h_l_m, org_w_l_m )
+            image_page_rotated = resize_image(image_page_rotated,org_h_l_m, org_w_l_m )
+
+        self.logger.info("detection of marginals took %.1fs", time.time() - t1)
+        #print("text region early 2 marginal in %.1fs", time.time() - t0)
+        ## birdan sora chock chakir
+        t1 = time.time()
+        if not self.full_layout:
+            polygons_of_images, img_revised_tab, text_regions_p_1_n, textline_mask_tot_d, regions_without_separators_d, \
+                boxes, boxes_d, polygons_of_marginals, contours_tables = \
+                self.run_boxes_no_full_layout(image_page, textline_mask_tot, text_regions_p, slope_deskew,
+                                              num_col_classifier, table_prediction, erosion_hurts)
+            ###polygons_of_marginals = self.dilate_textregions_contours(polygons_of_marginals)
+        else:
+            polygons_of_images, img_revised_tab, text_regions_p_1_n, textline_mask_tot_d, regions_without_separators_d, \
+                regions_fully, regions_without_separators, polygons_of_marginals, contours_tables = \
+                self.run_boxes_full_layout(image_page, textline_mask_tot, text_regions_p, slope_deskew,
+                                           num_col_classifier, img_only_regions, table_prediction, erosion_hurts,
+                                           img_bin_light if self.light_version else None)
+            ###polygons_of_marginals = self.dilate_textregions_contours(polygons_of_marginals)
+            if self.light_version:
+                drop_label_in_full_layout = 4
+                textline_mask_tot_ea_org[img_revised_tab==drop_label_in_full_layout] = 0
 
 
-            text_only = ((img_revised_tab[:, :] == 1)) * 1
+        text_only = ((img_revised_tab[:, :] == 1)) * 1
+        if np.abs(slope_deskew) >= SLOPE_THRESHOLD:
+            text_only_d = ((text_regions_p_1_n[:, :] == 1)) * 1
+
+        #print("text region early 2 in %.1fs", time.time() - t0)
+        ###min_con_area = 0.000005
+        contours_only_text, hir_on_text = return_contours_of_image(text_only)
+        contours_only_text_parent = return_parent_contours(contours_only_text, hir_on_text)
+        if len(contours_only_text_parent) > 0:
+            areas_cnt_text = np.array([cv2.contourArea(c) for c in contours_only_text_parent])
+            areas_cnt_text = areas_cnt_text / float(text_only.shape[0] * text_only.shape[1])
+            #self.logger.info('areas_cnt_text %s', areas_cnt_text)
+            contours_biggest = contours_only_text_parent[np.argmax(areas_cnt_text)]
+            contours_only_text_parent = [c for jz, c in enumerate(contours_only_text_parent)
+                                         if areas_cnt_text[jz] > MIN_AREA_REGION]
+            areas_cnt_text_parent = [area for area in areas_cnt_text if area > MIN_AREA_REGION]
+            index_con_parents = np.argsort(areas_cnt_text_parent)
+
+            contours_only_text_parent = self.return_list_of_contours_with_desired_order(
+                contours_only_text_parent, index_con_parents)
+
+            ##try:
+                ##contours_only_text_parent = \
+                    ##list(np.array(contours_only_text_parent,dtype=object)[index_con_parents])
+            ##except:
+                ##contours_only_text_parent = \
+                    ##list(np.array(contours_only_text_parent,dtype=np.int32)[index_con_parents])
+            ##areas_cnt_text_parent = list(np.array(areas_cnt_text_parent)[index_con_parents])
+            areas_cnt_text_parent = self.return_list_of_contours_with_desired_order(
+                areas_cnt_text_parent, index_con_parents)
+
+            cx_bigest_big, cy_biggest_big, _, _, _, _, _ = find_new_features_of_contours([contours_biggest])
+            cx_bigest, cy_biggest, _, _, _, _, _ = find_new_features_of_contours(contours_only_text_parent)
+
             if np.abs(slope_deskew) >= SLOPE_THRESHOLD:
-                text_only_d = ((text_regions_p_1_n[:, :] == 1)) * 1
+                contours_only_text_d, hir_on_text_d = return_contours_of_image(text_only_d)
+                contours_only_text_parent_d = return_parent_contours(contours_only_text_d, hir_on_text_d)
 
-            #print("text region early 2 in %.1fs", time.time() - t0)
-            ###min_con_area = 0.000005
-            contours_only_text, hir_on_text = return_contours_of_image(text_only)
-            contours_only_text_parent = return_parent_contours(contours_only_text, hir_on_text)
-            if len(contours_only_text_parent) > 0:
-                areas_cnt_text = np.array([cv2.contourArea(c) for c in contours_only_text_parent])
-                areas_cnt_text = areas_cnt_text / float(text_only.shape[0] * text_only.shape[1])
-                #self.logger.info('areas_cnt_text %s', areas_cnt_text)
-                contours_biggest = contours_only_text_parent[np.argmax(areas_cnt_text)]
-                contours_only_text_parent = [c for jz, c in enumerate(contours_only_text_parent)
-                                             if areas_cnt_text[jz] > MIN_AREA_REGION]
-                areas_cnt_text_parent = [area for area in areas_cnt_text if area > MIN_AREA_REGION]
-                index_con_parents = np.argsort(areas_cnt_text_parent)
+                areas_cnt_text_d = np.array([cv2.contourArea(c) for c in contours_only_text_parent_d])
+                areas_cnt_text_d = areas_cnt_text_d / float(text_only_d.shape[0] * text_only_d.shape[1])
 
-                contours_only_text_parent = self.return_list_of_contours_with_desired_order(
-                    contours_only_text_parent, index_con_parents)
+                if len(areas_cnt_text_d)>0:
+                    contours_biggest_d = contours_only_text_parent_d[np.argmax(areas_cnt_text_d)]
+                    index_con_parents_d = np.argsort(areas_cnt_text_d)
+                    contours_only_text_parent_d = self.return_list_of_contours_with_desired_order(
+                        contours_only_text_parent_d, index_con_parents_d)
+                    #try:
+                        #contours_only_text_parent_d = \
+                            #list(np.array(contours_only_text_parent_d,dtype=object)[index_con_parents_d])
+                    #except:
+                        #contours_only_text_parent_d = \
+                            #list(np.array(contours_only_text_parent_d,dtype=np.int32)[index_con_parents_d])
+                    #areas_cnt_text_d = list(np.array(areas_cnt_text_d)[index_con_parents_d])
+                    areas_cnt_text_d = self.return_list_of_contours_with_desired_order(
+                        areas_cnt_text_d, index_con_parents_d)
 
-                ##try:
-                    ##contours_only_text_parent = \
-                        ##list(np.array(contours_only_text_parent,dtype=object)[index_con_parents])
-                ##except:
-                    ##contours_only_text_parent = \
-                        ##list(np.array(contours_only_text_parent,dtype=np.int32)[index_con_parents])
-                ##areas_cnt_text_parent = list(np.array(areas_cnt_text_parent)[index_con_parents])
-                areas_cnt_text_parent = self.return_list_of_contours_with_desired_order(
-                    areas_cnt_text_parent, index_con_parents)
+                    cx_bigest_d_big, cy_biggest_d_big, _, _, _, _, _ = find_new_features_of_contours([contours_biggest_d])
+                    cx_bigest_d, cy_biggest_d, _, _, _, _, _ = find_new_features_of_contours(contours_only_text_parent_d)
+                    try:
+                        if len(cx_bigest_d) >= 5:
+                            cx_bigest_d_last5 = cx_bigest_d[-5:]
+                            cy_biggest_d_last5 = cy_biggest_d[-5:]
+                            dists_d = [math.sqrt((cx_bigest_big[0] - cx_bigest_d_last5[j]) ** 2 +
+                                                 (cy_biggest_big[0] - cy_biggest_d_last5[j]) ** 2)
+                                       for j in range(len(cy_biggest_d_last5))]
+                            ind_largest = len(cx_bigest_d) -5 + np.argmin(dists_d)
+                        else:
+                            cx_bigest_d_last5 = cx_bigest_d[-len(cx_bigest_d):]
+                            cy_biggest_d_last5 = cy_biggest_d[-len(cx_bigest_d):]
+                            dists_d = [math.sqrt((cx_bigest_big[0]-cx_bigest_d_last5[j])**2 +
+                                                 (cy_biggest_big[0]-cy_biggest_d_last5[j])**2)
+                                       for j in range(len(cy_biggest_d_last5))]
+                            ind_largest = len(cx_bigest_d) - len(cx_bigest_d) + np.argmin(dists_d)
 
-                cx_bigest_big, cy_biggest_big, _, _, _, _, _ = find_new_features_of_contours([contours_biggest])
-                cx_bigest, cy_biggest, _, _, _, _, _ = find_new_features_of_contours(contours_only_text_parent)
+                        cx_bigest_d_big[0] = cx_bigest_d[ind_largest]
+                        cy_biggest_d_big[0] = cy_biggest_d[ind_largest]
+                    except Exception as why:
+                        self.logger.error(why)
 
-                if np.abs(slope_deskew) >= SLOPE_THRESHOLD:
-                    contours_only_text_d, hir_on_text_d = return_contours_of_image(text_only_d)
-                    contours_only_text_parent_d = return_parent_contours(contours_only_text_d, hir_on_text_d)
+                    (h, w) = text_only.shape[:2]
+                    center = (w // 2.0, h // 2.0)
+                    M = cv2.getRotationMatrix2D(center, slope_deskew, 1.0)
+                    M_22 = np.array(M)[:2, :2]
+                    p_big = np.dot(M_22, [cx_bigest_big, cy_biggest_big])
+                    x_diff = p_big[0] - cx_bigest_d_big
+                    y_diff = p_big[1] - cy_biggest_d_big
 
-                    areas_cnt_text_d = np.array([cv2.contourArea(c) for c in contours_only_text_parent_d])
-                    areas_cnt_text_d = areas_cnt_text_d / float(text_only_d.shape[0] * text_only_d.shape[1])
-
-                    if len(areas_cnt_text_d)>0:
-                        contours_biggest_d = contours_only_text_parent_d[np.argmax(areas_cnt_text_d)]
-                        index_con_parents_d = np.argsort(areas_cnt_text_d)
-                        contours_only_text_parent_d = self.return_list_of_contours_with_desired_order(
-                            contours_only_text_parent_d, index_con_parents_d)
-                        #try:
-                            #contours_only_text_parent_d = \
-                                #list(np.array(contours_only_text_parent_d,dtype=object)[index_con_parents_d])
-                        #except:
-                            #contours_only_text_parent_d = \
-                                #list(np.array(contours_only_text_parent_d,dtype=np.int32)[index_con_parents_d])
-                        #areas_cnt_text_d = list(np.array(areas_cnt_text_d)[index_con_parents_d])
-                        areas_cnt_text_d = self.return_list_of_contours_with_desired_order(
-                            areas_cnt_text_d, index_con_parents_d)
-
-                        cx_bigest_d_big, cy_biggest_d_big, _, _, _, _, _ = find_new_features_of_contours([contours_biggest_d])
-                        cx_bigest_d, cy_biggest_d, _, _, _, _, _ = find_new_features_of_contours(contours_only_text_parent_d)
-                        try:
-                            if len(cx_bigest_d) >= 5:
-                                cx_bigest_d_last5 = cx_bigest_d[-5:]
-                                cy_biggest_d_last5 = cy_biggest_d[-5:]
-                                dists_d = [math.sqrt((cx_bigest_big[0] - cx_bigest_d_last5[j]) ** 2 +
-                                                     (cy_biggest_big[0] - cy_biggest_d_last5[j]) ** 2)
-                                           for j in range(len(cy_biggest_d_last5))]
-                                ind_largest = len(cx_bigest_d) -5 + np.argmin(dists_d)
-                            else:
-                                cx_bigest_d_last5 = cx_bigest_d[-len(cx_bigest_d):]
-                                cy_biggest_d_last5 = cy_biggest_d[-len(cx_bigest_d):]
-                                dists_d = [math.sqrt((cx_bigest_big[0]-cx_bigest_d_last5[j])**2 +
-                                                     (cy_biggest_big[0]-cy_biggest_d_last5[j])**2)
-                                           for j in range(len(cy_biggest_d_last5))]
-                                ind_largest = len(cx_bigest_d) - len(cx_bigest_d) + np.argmin(dists_d)
-
-                            cx_bigest_d_big[0] = cx_bigest_d[ind_largest]
-                            cy_biggest_d_big[0] = cy_biggest_d[ind_largest]
-                        except Exception as why:
-                            self.logger.error(why)
-
-                        (h, w) = text_only.shape[:2]
-                        center = (w // 2.0, h // 2.0)
-                        M = cv2.getRotationMatrix2D(center, slope_deskew, 1.0)
-                        M_22 = np.array(M)[:2, :2]
-                        p_big = np.dot(M_22, [cx_bigest_big, cy_biggest_big])
-                        x_diff = p_big[0] - cx_bigest_d_big
-                        y_diff = p_big[1] - cy_biggest_d_big
-
-                        contours_only_text_parent_d_ordered = []
-                        for i in range(len(contours_only_text_parent)):
-                            p = np.dot(M_22, [cx_bigest[i], cy_biggest[i]])
-                            p[0] = p[0] - x_diff[0]
-                            p[1] = p[1] - y_diff[0]
-                            dists = [math.sqrt((p[0] - cx_bigest_d[j]) ** 2 +
-                                               (p[1] - cy_biggest_d[j]) ** 2)
-                                     for j in range(len(cx_bigest_d))]
-                            contours_only_text_parent_d_ordered.append(contours_only_text_parent_d[np.argmin(dists)])
-                            # img2=np.zeros((text_only.shape[0],text_only.shape[1],3))
-                            # img2=cv2.fillPoly(img2,pts=[contours_only_text_parent_d[np.argmin(dists)]] ,color=(1,1,1))
-                            # plt.imshow(img2[:,:,0])
-                            # plt.show()
-                    else:
-                        contours_only_text_parent_d_ordered = []
-                        contours_only_text_parent_d = []
-                        contours_only_text_parent = []
-
+                    contours_only_text_parent_d_ordered = []
+                    for i in range(len(contours_only_text_parent)):
+                        p = np.dot(M_22, [cx_bigest[i], cy_biggest[i]])
+                        p[0] = p[0] - x_diff[0]
+                        p[1] = p[1] - y_diff[0]
+                        dists = [math.sqrt((p[0] - cx_bigest_d[j]) ** 2 +
+                                           (p[1] - cy_biggest_d[j]) ** 2)
+                                 for j in range(len(cx_bigest_d))]
+                        contours_only_text_parent_d_ordered.append(contours_only_text_parent_d[np.argmin(dists)])
+                        # img2=np.zeros((text_only.shape[0],text_only.shape[1],3))
+                        # img2=cv2.fillPoly(img2,pts=[contours_only_text_parent_d[np.argmin(dists)]] ,color=(1,1,1))
+                        # plt.imshow(img2[:,:,0])
+                        # plt.show()
                 else:
                     contours_only_text_parent_d_ordered = []
                     contours_only_text_parent_d = []
-                    #contours_only_text_parent = []
-            if not len(contours_only_text_parent):
-                # stop early
-                empty_marginals = [[]] * len(polygons_of_marginals)
-                if self.full_layout:
-                    pcgts = self.writer.build_pagexml_full_layout(
-                        [], [], page_coord, [], [], [], [], [], [],
-                        polygons_of_images, contours_tables, [],
-                        polygons_of_marginals, empty_marginals, empty_marginals, [], [], [],
-                        cont_page, polygons_lines_xml, [])
-                else:
-                    pcgts = self.writer.build_pagexml_no_full_layout(
-                        [], page_coord, [], [], [], [],
-                        polygons_of_images,
-                        polygons_of_marginals, empty_marginals, empty_marginals, [], [],
-                        cont_page, polygons_lines_xml, contours_tables, [])
-                return pcgts
+                    contours_only_text_parent = []
 
-            #print("text region early 3 in %.1fs", time.time() - t0)
-            if self.light_version:
-                contours_only_text_parent = self.dilate_textregions_contours(
-                    contours_only_text_parent)
-                contours_only_text_parent = self.filter_contours_inside_a_bigger_one(
-                    contours_only_text_parent, text_only, marginal_cnts=polygons_of_marginals)
-                #print("text region early 3.5 in %.1fs", time.time() - t0)
-                txt_con_org = get_textregion_contours_in_org_image_light(
-                    contours_only_text_parent, self.image, slope_first, map=self.executor.map)
-                #txt_con_org = self.dilate_textregions_contours(txt_con_org)
-                #contours_only_text_parent = self.dilate_textregions_contours(contours_only_text_parent)
             else:
-                txt_con_org = get_textregion_contours_in_org_image(
-                    contours_only_text_parent, self.image, slope_first)
-            #print("text region early 4 in %.1fs", time.time() - t0)
-            boxes_text, _ = get_text_region_boxes_by_given_contours(contours_only_text_parent)
-            boxes_marginals, _ = get_text_region_boxes_by_given_contours(polygons_of_marginals)
-            #print("text region early 5 in %.1fs", time.time() - t0)
-            ## birdan sora chock chakir
-            if not self.curved_line:
-                if self.light_version:
-                    if self.textline_light:
-                        all_found_textline_polygons, boxes_text, txt_con_org, contours_only_text_parent, \
-                            all_box_coord, index_by_text_par_con, slopes = self.get_slopes_and_deskew_new_light2(
-                                txt_con_org, contours_only_text_parent, textline_mask_tot_ea_org,
-                                image_page_rotated, boxes_text, slope_deskew)
-                        all_found_textline_polygons_marginals, boxes_marginals, _, polygons_of_marginals, \
-                            all_box_coord_marginals, _, slopes_marginals = self.get_slopes_and_deskew_new_light2(
-                                polygons_of_marginals, polygons_of_marginals, textline_mask_tot_ea_org,
-                                image_page_rotated, boxes_marginals, slope_deskew)
+                contours_only_text_parent_d_ordered = []
+                contours_only_text_parent_d = []
+                #contours_only_text_parent = []
+        if not len(contours_only_text_parent):
+            # stop early
+            empty_marginals = [[]] * len(polygons_of_marginals)
+            if self.full_layout:
+                pcgts = self.writer.build_pagexml_full_layout(
+                    [], [], page_coord, [], [], [], [], [], [],
+                    polygons_of_images, contours_tables, [],
+                    polygons_of_marginals, empty_marginals, empty_marginals, [], [], [],
+                    cont_page, polygons_lines_xml, [])
+            else:
+                pcgts = self.writer.build_pagexml_no_full_layout(
+                    [], page_coord, [], [], [], [],
+                    polygons_of_images,
+                    polygons_of_marginals, empty_marginals, empty_marginals, [], [],
+                    cont_page, polygons_lines_xml, contours_tables, [])
+            return pcgts
 
-                        #slopes, all_found_textline_polygons, boxes_text, txt_con_org, contours_only_text_parent, index_by_text_par_con = \
-                        #    self.delete_regions_without_textlines(slopes, all_found_textline_polygons,
-                        #        boxes_text, txt_con_org, contours_only_text_parent, index_by_text_par_con)
-                        #slopes_marginals, all_found_textline_polygons_marginals, boxes_marginals, polygons_of_marginals, polygons_of_marginals, _ = \
-                        #    self.delete_regions_without_textlines(slopes_marginals, all_found_textline_polygons_marginals,
-                        #        boxes_marginals, polygons_of_marginals, polygons_of_marginals, np.array(range(len(polygons_of_marginals))))
-                        #all_found_textline_polygons = self.dilate_textlines(all_found_textline_polygons)
-                        #####all_found_textline_polygons = self.dilate_textline_contours(all_found_textline_polygons)
-                        all_found_textline_polygons = self.dilate_textregions_contours_textline_version(
-                            all_found_textline_polygons)
-                        all_found_textline_polygons = self.filter_contours_inside_a_bigger_one(
-                            all_found_textline_polygons, textline_mask_tot_ea_org, type_contour="textline")
-                        all_found_textline_polygons_marginals = self.dilate_textregions_contours_textline_version(
-                            all_found_textline_polygons_marginals)
-                        contours_only_text_parent, txt_con_org, all_found_textline_polygons, contours_only_text_parent_d_ordered, \
-                            index_by_text_par_con = self.filter_contours_without_textline_inside(
-                                contours_only_text_parent, txt_con_org, all_found_textline_polygons, contours_only_text_parent_d_ordered)
-                    else:
-                        textline_mask_tot_ea = cv2.erode(textline_mask_tot_ea, kernel=KERNEL, iterations=1)
-                        all_found_textline_polygons, boxes_text, txt_con_org, contours_only_text_parent, all_box_coord, \
-                            index_by_text_par_con, slopes = self.get_slopes_and_deskew_new_light(
-                                txt_con_org, contours_only_text_parent, textline_mask_tot_ea,
-                                image_page_rotated, boxes_text, slope_deskew)
-                        all_found_textline_polygons_marginals, boxes_marginals, _, polygons_of_marginals, \
-                            all_box_coord_marginals, _, slopes_marginals = self.get_slopes_and_deskew_new_light(
-                                polygons_of_marginals, polygons_of_marginals, textline_mask_tot_ea,
-                                image_page_rotated, boxes_marginals, slope_deskew)
-                        #all_found_textline_polygons = self.filter_contours_inside_a_bigger_one(
-                        #    all_found_textline_polygons, textline_mask_tot_ea_org, type_contour="textline")
+        #print("text region early 3 in %.1fs", time.time() - t0)
+        if self.light_version:
+            contours_only_text_parent = self.dilate_textregions_contours(
+                contours_only_text_parent)
+            contours_only_text_parent = self.filter_contours_inside_a_bigger_one(
+                contours_only_text_parent, text_only, marginal_cnts=polygons_of_marginals)
+            #print("text region early 3.5 in %.1fs", time.time() - t0)
+            txt_con_org = get_textregion_contours_in_org_image_light(
+                contours_only_text_parent, self.image, slope_first, map=self.executor.map)
+            #txt_con_org = self.dilate_textregions_contours(txt_con_org)
+            #contours_only_text_parent = self.dilate_textregions_contours(contours_only_text_parent)
+        else:
+            txt_con_org = get_textregion_contours_in_org_image(
+                contours_only_text_parent, self.image, slope_first)
+        #print("text region early 4 in %.1fs", time.time() - t0)
+        boxes_text, _ = get_text_region_boxes_by_given_contours(contours_only_text_parent)
+        boxes_marginals, _ = get_text_region_boxes_by_given_contours(polygons_of_marginals)
+        #print("text region early 5 in %.1fs", time.time() - t0)
+        ## birdan sora chock chakir
+        if not self.curved_line:
+            if self.light_version:
+                if self.textline_light:
+                    all_found_textline_polygons, boxes_text, txt_con_org, contours_only_text_parent, \
+                        all_box_coord, index_by_text_par_con, slopes = self.get_slopes_and_deskew_new_light2(
+                            txt_con_org, contours_only_text_parent, textline_mask_tot_ea_org,
+                            image_page_rotated, boxes_text, slope_deskew)
+                    all_found_textline_polygons_marginals, boxes_marginals, _, polygons_of_marginals, \
+                        all_box_coord_marginals, _, slopes_marginals = self.get_slopes_and_deskew_new_light2(
+                            polygons_of_marginals, polygons_of_marginals, textline_mask_tot_ea_org,
+                            image_page_rotated, boxes_marginals, slope_deskew)
+
+                    #slopes, all_found_textline_polygons, boxes_text, txt_con_org, contours_only_text_parent, index_by_text_par_con = \
+                    #    self.delete_regions_without_textlines(slopes, all_found_textline_polygons,
+                    #        boxes_text, txt_con_org, contours_only_text_parent, index_by_text_par_con)
+                    #slopes_marginals, all_found_textline_polygons_marginals, boxes_marginals, polygons_of_marginals, polygons_of_marginals, _ = \
+                    #    self.delete_regions_without_textlines(slopes_marginals, all_found_textline_polygons_marginals,
+                    #        boxes_marginals, polygons_of_marginals, polygons_of_marginals, np.array(range(len(polygons_of_marginals))))
+                    #all_found_textline_polygons = self.dilate_textlines(all_found_textline_polygons)
+                    #####all_found_textline_polygons = self.dilate_textline_contours(all_found_textline_polygons)
+                    all_found_textline_polygons = self.dilate_textregions_contours_textline_version(
+                        all_found_textline_polygons)
+                    all_found_textline_polygons = self.filter_contours_inside_a_bigger_one(
+                        all_found_textline_polygons, textline_mask_tot_ea_org, type_contour="textline")
+                    all_found_textline_polygons_marginals = self.dilate_textregions_contours_textline_version(
+                        all_found_textline_polygons_marginals)
+                    contours_only_text_parent, txt_con_org, all_found_textline_polygons, contours_only_text_parent_d_ordered, \
+                        index_by_text_par_con = self.filter_contours_without_textline_inside(
+                            contours_only_text_parent, txt_con_org, all_found_textline_polygons, contours_only_text_parent_d_ordered)
                 else:
                     textline_mask_tot_ea = cv2.erode(textline_mask_tot_ea, kernel=KERNEL, iterations=1)
-                    all_found_textline_polygons, boxes_text, txt_con_org, contours_only_text_parent, \
-                        all_box_coord, index_by_text_par_con, slopes = self.get_slopes_and_deskew_new(
+                    all_found_textline_polygons, boxes_text, txt_con_org, contours_only_text_parent, all_box_coord, \
+                        index_by_text_par_con, slopes = self.get_slopes_and_deskew_new_light(
                             txt_con_org, contours_only_text_parent, textline_mask_tot_ea,
                             image_page_rotated, boxes_text, slope_deskew)
                     all_found_textline_polygons_marginals, boxes_marginals, _, polygons_of_marginals, \
-                        all_box_coord_marginals, _, slopes_marginals = self.get_slopes_and_deskew_new(
+                        all_box_coord_marginals, _, slopes_marginals = self.get_slopes_and_deskew_new_light(
                             polygons_of_marginals, polygons_of_marginals, textline_mask_tot_ea,
                             image_page_rotated, boxes_marginals, slope_deskew)
+                    #all_found_textline_polygons = self.filter_contours_inside_a_bigger_one(
+                    #    all_found_textline_polygons, textline_mask_tot_ea_org, type_contour="textline")
             else:
-                scale_param = 1
-                textline_mask_tot_ea_erode = cv2.erode(textline_mask_tot_ea, kernel=KERNEL, iterations=2)
+                textline_mask_tot_ea = cv2.erode(textline_mask_tot_ea, kernel=KERNEL, iterations=1)
                 all_found_textline_polygons, boxes_text, txt_con_org, contours_only_text_parent, \
-                    all_box_coord, index_by_text_par_con, slopes = self.get_slopes_and_deskew_new_curved(
-                        txt_con_org, contours_only_text_parent, textline_mask_tot_ea_erode,
-                        image_page_rotated, boxes_text, text_only,
-                        num_col_classifier, scale_param, slope_deskew)
-                all_found_textline_polygons = small_textlines_to_parent_adherence2(
-                    all_found_textline_polygons, textline_mask_tot_ea, num_col_classifier)
+                    all_box_coord, index_by_text_par_con, slopes = self.get_slopes_and_deskew_new(
+                        txt_con_org, contours_only_text_parent, textline_mask_tot_ea,
+                        image_page_rotated, boxes_text, slope_deskew)
                 all_found_textline_polygons_marginals, boxes_marginals, _, polygons_of_marginals, \
-                    all_box_coord_marginals, _, slopes_marginals = self.get_slopes_and_deskew_new_curved(
-                        polygons_of_marginals, polygons_of_marginals, textline_mask_tot_ea_erode,
-                        image_page_rotated, boxes_marginals, text_only,
-                        num_col_classifier, scale_param, slope_deskew)
-                all_found_textline_polygons_marginals = small_textlines_to_parent_adherence2(
-                    all_found_textline_polygons_marginals, textline_mask_tot_ea, num_col_classifier)
+                    all_box_coord_marginals, _, slopes_marginals = self.get_slopes_and_deskew_new(
+                        polygons_of_marginals, polygons_of_marginals, textline_mask_tot_ea,
+                        image_page_rotated, boxes_marginals, slope_deskew)
+        else:
+            scale_param = 1
+            textline_mask_tot_ea_erode = cv2.erode(textline_mask_tot_ea, kernel=KERNEL, iterations=2)
+            all_found_textline_polygons, boxes_text, txt_con_org, contours_only_text_parent, \
+                all_box_coord, index_by_text_par_con, slopes = self.get_slopes_and_deskew_new_curved(
+                    txt_con_org, contours_only_text_parent, textline_mask_tot_ea_erode,
+                    image_page_rotated, boxes_text, text_only,
+                    num_col_classifier, scale_param, slope_deskew)
+            all_found_textline_polygons = small_textlines_to_parent_adherence2(
+                all_found_textline_polygons, textline_mask_tot_ea, num_col_classifier)
+            all_found_textline_polygons_marginals, boxes_marginals, _, polygons_of_marginals, \
+                all_box_coord_marginals, _, slopes_marginals = self.get_slopes_and_deskew_new_curved(
+                    polygons_of_marginals, polygons_of_marginals, textline_mask_tot_ea_erode,
+                    image_page_rotated, boxes_marginals, text_only,
+                    num_col_classifier, scale_param, slope_deskew)
+            all_found_textline_polygons_marginals = small_textlines_to_parent_adherence2(
+                all_found_textline_polygons_marginals, textline_mask_tot_ea, num_col_classifier)
 
-            #print("text region early 6 in %.1fs", time.time() - t0)
-            if self.full_layout:
-                if np.abs(slope_deskew) >= SLOPE_THRESHOLD:
-                    contours_only_text_parent_d_ordered = self.return_list_of_contours_with_desired_order(
-                        contours_only_text_parent_d_ordered, index_by_text_par_con)
-                    #try:
-                        #contours_only_text_parent_d_ordered = \
-                            #list(np.array(contours_only_text_parent_d_ordered, dtype=np.int32)[index_by_text_par_con])
-                    #except:
-                        #contours_only_text_parent_d_ordered = \
-                            #list(np.array(contours_only_text_parent_d_ordered, dtype=object)[index_by_text_par_con])
-                else:
-                    #takes long timee
-                    contours_only_text_parent_d_ordered = None
-                if self.light_version:
-                    fun = check_any_text_region_in_model_one_is_main_or_header_light
-                else:
-                    fun = check_any_text_region_in_model_one_is_main_or_header
-                text_regions_p, contours_only_text_parent, contours_only_text_parent_h, all_box_coord, all_box_coord_h, \
-                    all_found_textline_polygons, all_found_textline_polygons_h, slopes, slopes_h, \
-                    contours_only_text_parent_d_ordered, contours_only_text_parent_h_d_ordered = fun(
-                        text_regions_p, regions_fully, contours_only_text_parent,
-                        all_box_coord, all_found_textline_polygons, slopes, contours_only_text_parent_d_ordered)
-
-                if self.plotter:
-                    self.plotter.save_plot_of_layout(text_regions_p, image_page)
-                    self.plotter.save_plot_of_layout_all(text_regions_p, image_page)
-
-                pixel_img = 4
-                polygons_of_drop_capitals = return_contours_of_interested_region_by_min_size(text_regions_p, pixel_img)
-                all_found_textline_polygons = adhere_drop_capital_region_into_corresponding_textline(
-                    text_regions_p, polygons_of_drop_capitals, contours_only_text_parent, contours_only_text_parent_h,
-                    all_box_coord, all_box_coord_h, all_found_textline_polygons, all_found_textline_polygons_h,
-                    kernel=KERNEL, curved_line=self.curved_line, textline_light=self.textline_light)
-
-                if not self.reading_order_machine_based:
-                    pixel_seps = 6
-                    if not self.headers_off:
-                        if np.abs(slope_deskew) < SLOPE_THRESHOLD:
-                            num_col, _, matrix_of_lines_ch, splitter_y_new, _ = find_number_of_columns_in_document(
-                                np.repeat(text_regions_p[:, :, np.newaxis], 3, axis=2),
-                                num_col_classifier, self.tables,  pixel_seps, contours_only_text_parent_h)
-                        else:
-                            _, _, matrix_of_lines_ch_d, splitter_y_new_d, _ = find_number_of_columns_in_document(
-                                np.repeat(text_regions_p_1_n[:, :, np.newaxis], 3, axis=2),
-                                num_col_classifier, self.tables, pixel_seps, contours_only_text_parent_h_d_ordered)
-                    elif self.headers_off:
-                        if np.abs(slope_deskew) < SLOPE_THRESHOLD:
-                            num_col, _, matrix_of_lines_ch, splitter_y_new, _ = find_number_of_columns_in_document(
-                                np.repeat(text_regions_p[:, :, np.newaxis], 3, axis=2),
-                                num_col_classifier, self.tables,  pixel_seps)
-                        else:
-                            _, _, matrix_of_lines_ch_d, splitter_y_new_d, _ = find_number_of_columns_in_document(
-                                np.repeat(text_regions_p_1_n[:, :, np.newaxis], 3, axis=2),
-                                num_col_classifier, self.tables, pixel_seps)
-
-                    if num_col_classifier >= 3:
-                        if np.abs(slope_deskew) < SLOPE_THRESHOLD:
-                            regions_without_separators = regions_without_separators.astype(np.uint8)
-                            regions_without_separators = cv2.erode(regions_without_separators[:, :], KERNEL, iterations=6)
-                        else:
-                            regions_without_separators_d = regions_without_separators_d.astype(np.uint8)
-                            regions_without_separators_d = cv2.erode(regions_without_separators_d[:, :], KERNEL, iterations=6)
-
-                    if np.abs(slope_deskew) < SLOPE_THRESHOLD:
-                        boxes, peaks_neg_tot_tables = return_boxes_of_images_by_order_of_reading_new(
-                            splitter_y_new, regions_without_separators, matrix_of_lines_ch,
-                            num_col_classifier, erosion_hurts, self.tables, self.right2left)
-                    else:
-                        boxes_d, peaks_neg_tot_tables_d = return_boxes_of_images_by_order_of_reading_new(
-                            splitter_y_new_d, regions_without_separators_d, matrix_of_lines_ch_d,
-                            num_col_classifier, erosion_hurts, self.tables, self.right2left)     
+        #print("text region early 6 in %.1fs", time.time() - t0)
+        if self.full_layout:
+            if np.abs(slope_deskew) >= SLOPE_THRESHOLD:
+                contours_only_text_parent_d_ordered = self.return_list_of_contours_with_desired_order(
+                    contours_only_text_parent_d_ordered, index_by_text_par_con)
+                #try:
+                    #contours_only_text_parent_d_ordered = \
+                        #list(np.array(contours_only_text_parent_d_ordered, dtype=np.int32)[index_by_text_par_con])
+                #except:
+                    #contours_only_text_parent_d_ordered = \
+                        #list(np.array(contours_only_text_parent_d_ordered, dtype=object)[index_by_text_par_con])
+            else:
+                #takes long timee
+                contours_only_text_parent_d_ordered = None
+            if self.light_version:
+                fun = check_any_text_region_in_model_one_is_main_or_header_light
+            else:
+                fun = check_any_text_region_in_model_one_is_main_or_header
+            text_regions_p, contours_only_text_parent, contours_only_text_parent_h, all_box_coord, all_box_coord_h, \
+                all_found_textline_polygons, all_found_textline_polygons_h, slopes, slopes_h, \
+                contours_only_text_parent_d_ordered, contours_only_text_parent_h_d_ordered = fun(
+                    text_regions_p, regions_fully, contours_only_text_parent,
+                    all_box_coord, all_found_textline_polygons, slopes, contours_only_text_parent_d_ordered)
 
             if self.plotter:
-                self.plotter.write_images_into_directory(polygons_of_images, image_page)
-            t_order = time.time()
+                self.plotter.save_plot_of_layout(text_regions_p, image_page)
+                self.plotter.save_plot_of_layout_all(text_regions_p, image_page)
 
-            if self.full_layout:
-                if self.reading_order_machine_based:
-                    order_text_new, id_of_texts_tot = self.do_order_of_regions_with_model(
-                        contours_only_text_parent, contours_only_text_parent_h, text_regions_p)
-                else:
+            pixel_img = 4
+            polygons_of_drop_capitals = return_contours_of_interested_region_by_min_size(text_regions_p, pixel_img)
+            all_found_textline_polygons = adhere_drop_capital_region_into_corresponding_textline(
+                text_regions_p, polygons_of_drop_capitals, contours_only_text_parent, contours_only_text_parent_h,
+                all_box_coord, all_box_coord_h, all_found_textline_polygons, all_found_textline_polygons_h,
+                kernel=KERNEL, curved_line=self.curved_line, textline_light=self.textline_light)
+
+            if not self.reading_order_machine_based:
+                pixel_seps = 6
+                if not self.headers_off:
                     if np.abs(slope_deskew) < SLOPE_THRESHOLD:
-                        order_text_new, id_of_texts_tot = self.do_order_of_regions(
-                            contours_only_text_parent, contours_only_text_parent_h, boxes, textline_mask_tot)
+                        num_col, _, matrix_of_lines_ch, splitter_y_new, _ = find_number_of_columns_in_document(
+                            np.repeat(text_regions_p[:, :, np.newaxis], 3, axis=2),
+                            num_col_classifier, self.tables,  pixel_seps, contours_only_text_parent_h)
                     else:
-                        order_text_new, id_of_texts_tot = self.do_order_of_regions(
-                            contours_only_text_parent_d_ordered, contours_only_text_parent_h_d_ordered, boxes_d, textline_mask_tot_d)
-                self.logger.info("detection of reading order took %.1fs", time.time() - t_order)
+                        _, _, matrix_of_lines_ch_d, splitter_y_new_d, _ = find_number_of_columns_in_document(
+                            np.repeat(text_regions_p_1_n[:, :, np.newaxis], 3, axis=2),
+                            num_col_classifier, self.tables, pixel_seps, contours_only_text_parent_h_d_ordered)
+                elif self.headers_off:
+                    if np.abs(slope_deskew) < SLOPE_THRESHOLD:
+                        num_col, _, matrix_of_lines_ch, splitter_y_new, _ = find_number_of_columns_in_document(
+                            np.repeat(text_regions_p[:, :, np.newaxis], 3, axis=2),
+                            num_col_classifier, self.tables,  pixel_seps)
+                    else:
+                        _, _, matrix_of_lines_ch_d, splitter_y_new_d, _ = find_number_of_columns_in_document(
+                            np.repeat(text_regions_p_1_n[:, :, np.newaxis], 3, axis=2),
+                            num_col_classifier, self.tables, pixel_seps)
 
-                if self.ocr:
-                    ocr_all_textlines = []
+                if num_col_classifier >= 3:
+                    if np.abs(slope_deskew) < SLOPE_THRESHOLD:
+                        regions_without_separators = regions_without_separators.astype(np.uint8)
+                        regions_without_separators = cv2.erode(regions_without_separators[:, :], KERNEL, iterations=6)
+                    else:
+                        regions_without_separators_d = regions_without_separators_d.astype(np.uint8)
+                        regions_without_separators_d = cv2.erode(regions_without_separators_d[:, :], KERNEL, iterations=6)
+
+                if np.abs(slope_deskew) < SLOPE_THRESHOLD:
+                    boxes, peaks_neg_tot_tables = return_boxes_of_images_by_order_of_reading_new(
+                        splitter_y_new, regions_without_separators, matrix_of_lines_ch,
+                        num_col_classifier, erosion_hurts, self.tables, self.right2left)
                 else:
-                    ocr_all_textlines = None
-                pcgts = self.writer.build_pagexml_full_layout(
-                    contours_only_text_parent, contours_only_text_parent_h, page_coord, order_text_new, id_of_texts_tot,
-                    all_found_textline_polygons, all_found_textline_polygons_h, all_box_coord, all_box_coord_h,
-                    polygons_of_images, contours_tables, polygons_of_drop_capitals, polygons_of_marginals,
-                    all_found_textline_polygons_marginals, all_box_coord_marginals, slopes, slopes_h, slopes_marginals,
-                    cont_page, polygons_lines_xml, ocr_all_textlines)
-                return pcgts
+                    boxes_d, peaks_neg_tot_tables_d = return_boxes_of_images_by_order_of_reading_new(
+                        splitter_y_new_d, regions_without_separators_d, matrix_of_lines_ch_d,
+                        num_col_classifier, erosion_hurts, self.tables, self.right2left)
 
+        if self.plotter:
+            self.plotter.write_images_into_directory(polygons_of_images, image_page)
+        t_order = time.time()
+
+        if self.full_layout:
+            if self.reading_order_machine_based:
+                order_text_new, id_of_texts_tot = self.do_order_of_regions_with_model(
+                    contours_only_text_parent, contours_only_text_parent_h, text_regions_p)
             else:
-                contours_only_text_parent_h = None
-                if self.reading_order_machine_based:
-                    order_text_new, id_of_texts_tot = self.do_order_of_regions_with_model(
-                        contours_only_text_parent, contours_only_text_parent_h, text_regions_p)
+                if np.abs(slope_deskew) < SLOPE_THRESHOLD:
+                    order_text_new, id_of_texts_tot = self.do_order_of_regions(
+                        contours_only_text_parent, contours_only_text_parent_h, boxes, textline_mask_tot)
                 else:
-                    if np.abs(slope_deskew) < SLOPE_THRESHOLD:
-                        order_text_new, id_of_texts_tot = self.do_order_of_regions(
-                            contours_only_text_parent, contours_only_text_parent_h, boxes, textline_mask_tot)
+                    order_text_new, id_of_texts_tot = self.do_order_of_regions(
+                        contours_only_text_parent_d_ordered, contours_only_text_parent_h_d_ordered, boxes_d, textline_mask_tot_d)
+            self.logger.info("detection of reading order took %.1fs", time.time() - t_order)
+
+            if self.ocr:
+                ocr_all_textlines = []
+            else:
+                ocr_all_textlines = None
+            pcgts = self.writer.build_pagexml_full_layout(
+                contours_only_text_parent, contours_only_text_parent_h, page_coord, order_text_new, id_of_texts_tot,
+                all_found_textline_polygons, all_found_textline_polygons_h, all_box_coord, all_box_coord_h,
+                polygons_of_images, contours_tables, polygons_of_drop_capitals, polygons_of_marginals,
+                all_found_textline_polygons_marginals, all_box_coord_marginals, slopes, slopes_h, slopes_marginals,
+                cont_page, polygons_lines_xml, ocr_all_textlines)
+            return pcgts
+
+        contours_only_text_parent_h = None
+        if self.reading_order_machine_based:
+            order_text_new, id_of_texts_tot = self.do_order_of_regions_with_model(
+                contours_only_text_parent, contours_only_text_parent_h, text_regions_p)
+        else:
+            if np.abs(slope_deskew) < SLOPE_THRESHOLD:
+                order_text_new, id_of_texts_tot = self.do_order_of_regions(
+                    contours_only_text_parent, contours_only_text_parent_h, boxes, textline_mask_tot)
+            else:
+                contours_only_text_parent_d_ordered = self.return_list_of_contours_with_desired_order(
+                    contours_only_text_parent_d_ordered, index_by_text_par_con)
+                #try:
+                    #contours_only_text_parent_d_ordered = \
+                        #list(np.array(contours_only_text_parent_d_ordered, dtype=object)[index_by_text_par_con])
+                #except:
+                    #contours_only_text_parent_d_ordered = \
+                        #list(np.array(contours_only_text_parent_d_ordered, dtype=np.int32)[index_by_text_par_con])
+                order_text_new, id_of_texts_tot = self.do_order_of_regions(
+                    contours_only_text_parent_d_ordered, contours_only_text_parent_h, boxes_d, textline_mask_tot_d)
+
+        if self.ocr:
+            device = cuda.get_current_device()
+            device.reset()
+            gc.collect()
+            model_ocr = VisionEncoderDecoderModel.from_pretrained(self.model_ocr_dir)
+            device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+            processor = TrOCRProcessor.from_pretrained("microsoft/trocr-base-printed")
+            torch.cuda.empty_cache()
+            model_ocr.to(device)
+
+            ind_tot = 0
+            #cv2.imwrite('./img_out.png', image_page)
+            ocr_all_textlines = []
+            for indexing, ind_poly_first in enumerate(all_found_textline_polygons):
+                ocr_textline_in_textregion = []
+                for indexing2, ind_poly in enumerate(ind_poly_first):
+                    if not (self.textline_light or self.curved_line):
+                        ind_poly = copy.deepcopy(ind_poly)
+                        box_ind = all_box_coord[indexing]
+                        #print(ind_poly,np.shape(ind_poly), 'ind_poly')
+                        #print(box_ind)
+                        ind_poly = self.return_textline_contour_with_added_box_coordinate(ind_poly, box_ind)
+                        #print(ind_poly_copy)
+                        ind_poly[ind_poly<0] = 0
+                    x, y, w, h = cv2.boundingRect(ind_poly)
+                    #print(ind_poly_copy, np.shape(ind_poly_copy))
+                    #print(x, y, w, h, h/float(w),'ratio')
+                    h2w_ratio = h/float(w)
+                    mask_poly = np.zeros(image_page.shape)
+                    if not self.light_version:
+                        img_poly_on_img = np.copy(image_page)
                     else:
-                        contours_only_text_parent_d_ordered = self.return_list_of_contours_with_desired_order(
-                            contours_only_text_parent_d_ordered, index_by_text_par_con)
-                        #try:
-                            #contours_only_text_parent_d_ordered = \
-                                #list(np.array(contours_only_text_parent_d_ordered, dtype=object)[index_by_text_par_con])
-                        #except:
-                            #contours_only_text_parent_d_ordered = \
-                                #list(np.array(contours_only_text_parent_d_ordered, dtype=np.int32)[index_by_text_par_con])
-                        order_text_new, id_of_texts_tot = self.do_order_of_regions(
-                            contours_only_text_parent_d_ordered, contours_only_text_parent_h, boxes_d, textline_mask_tot_d)
+                        img_poly_on_img = np.copy(img_bin_light)
+                    mask_poly = cv2.fillPoly(mask_poly, pts=[ind_poly], color=(1, 1, 1))
 
-                if self.ocr:
-                    device = cuda.get_current_device()
-                    device.reset()
-                    gc.collect()
-                    model_ocr = VisionEncoderDecoderModel.from_pretrained(self.model_ocr_dir)
-                    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-                    processor = TrOCRProcessor.from_pretrained("microsoft/trocr-base-printed")
-                    torch.cuda.empty_cache()
-                    model_ocr.to(device)
+                    if self.textline_light:
+                        mask_poly = cv2.dilate(mask_poly, KERNEL, iterations=1)
+                    img_poly_on_img[:,:,0][mask_poly[:,:,0] ==0] = 255
+                    img_poly_on_img[:,:,1][mask_poly[:,:,0] ==0] = 255
+                    img_poly_on_img[:,:,2][mask_poly[:,:,0] ==0] = 255
 
-                    ind_tot = 0
-                    #cv2.imwrite('./img_out.png', image_page)
-                    ocr_all_textlines = []
-                    for indexing, ind_poly_first in enumerate(all_found_textline_polygons):
-                        ocr_textline_in_textregion = []
-                        for indexing2, ind_poly in enumerate(ind_poly_first):
-                            if not (self.textline_light or self.curved_line):
-                                ind_poly = copy.deepcopy(ind_poly)
-                                box_ind = all_box_coord[indexing]
-                                #print(ind_poly,np.shape(ind_poly), 'ind_poly')
-                                #print(box_ind)
-                                ind_poly = self.return_textline_contour_with_added_box_coordinate(ind_poly, box_ind)
-                                #print(ind_poly_copy)
-                                ind_poly[ind_poly<0] = 0
-                            x, y, w, h = cv2.boundingRect(ind_poly)
-                            #print(ind_poly_copy, np.shape(ind_poly_copy))
-                            #print(x, y, w, h, h/float(w),'ratio')
-                            h2w_ratio = h/float(w)
-                            mask_poly = np.zeros(image_page.shape)
-                            if not self.light_version:
-                                img_poly_on_img = np.copy(image_page)
-                            else:
-                                img_poly_on_img = np.copy(img_bin_light)
-                            mask_poly = cv2.fillPoly(mask_poly, pts=[ind_poly], color=(1, 1, 1))
+                    img_croped = img_poly_on_img[y:y+h, x:x+w, :]
+                    #cv2.imwrite('./extracted_lines/'+str(ind_tot)+'.jpg', img_croped)
+                    text_ocr = self.return_ocr_of_textline_without_common_section(img_croped, model_ocr, processor, device, w, h2w_ratio, ind_tot)
+                    ocr_textline_in_textregion.append(text_ocr)
+                    ind_tot = ind_tot +1
+                ocr_all_textlines.append(ocr_textline_in_textregion)
 
-                            if self.textline_light:
-                                mask_poly = cv2.dilate(mask_poly, KERNEL, iterations=1)
-                            img_poly_on_img[:,:,0][mask_poly[:,:,0] ==0] = 255
-                            img_poly_on_img[:,:,1][mask_poly[:,:,0] ==0] = 255
-                            img_poly_on_img[:,:,2][mask_poly[:,:,0] ==0] = 255
-
-                            img_croped = img_poly_on_img[y:y+h, x:x+w, :]
-                            #cv2.imwrite('./extracted_lines/'+str(ind_tot)+'.jpg', img_croped)
-                            text_ocr = self.return_ocr_of_textline_without_common_section(img_croped, model_ocr, processor, device, w, h2w_ratio, ind_tot)
-                            ocr_textline_in_textregion.append(text_ocr)
-                            ind_tot = ind_tot +1
-                        ocr_all_textlines.append(ocr_textline_in_textregion)
-
-                else:
-                    ocr_all_textlines = None
-                #print(ocr_all_textlines)
-                self.logger.info("detection of reading order took %.1fs", time.time() - t_order)
-                pcgts = self.writer.build_pagexml_no_full_layout(
-                    txt_con_org, page_coord, order_text_new, id_of_texts_tot,
-                    all_found_textline_polygons, all_box_coord, polygons_of_images, polygons_of_marginals,
-                    all_found_textline_polygons_marginals, all_box_coord_marginals, slopes, slopes_marginals,
-                    cont_page, polygons_lines_xml, contours_tables, ocr_all_textlines)
-                return pcgts
+        else:
+            ocr_all_textlines = None
+            #print(ocr_all_textlines)
+        self.logger.info("detection of reading order took %.1fs", time.time() - t_order)
+        pcgts = self.writer.build_pagexml_no_full_layout(
+            txt_con_org, page_coord, order_text_new, id_of_texts_tot,
+            all_found_textline_polygons, all_box_coord, polygons_of_images, polygons_of_marginals,
+            all_found_textline_polygons_marginals, all_box_coord_marginals, slopes, slopes_marginals,
+            cont_page, polygons_lines_xml, contours_tables, ocr_all_textlines)
+        return pcgts
 
 
 class Eynollah_ocr:

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4223,10 +4223,7 @@ class Eynollah:
             pcgts = self.run_single()
             self.logger.info("Job done in %.1fs", time.time() - t0)
             #print("Job done in %.1fs" % (time.time() - t0))
-            if dir_in:
-                self.writer.write_pagexml(pcgts)
-            else:
-                return pcgts
+            self.writer.write_pagexml(pcgts)
 
         if dir_in:
             self.logger.info("All jobs done in %.1fs", time.time() - t0_tot)

--- a/src/eynollah/processor.py
+++ b/src/eynollah/processor.py
@@ -30,11 +30,7 @@ class EynollahProcessor(Processor):
             allow_scaling=self.parameter['allow_scaling'],
             headers_off=self.parameter['headers_off'],
             tables=self.parameter['tables'],
-            override_dpi=self.parameter['dpi'],
-            # trick Eynollah to do init independent of an image
-            dir_in="."
         )
-        self.eynollah.dir_in = None
         self.eynollah.plotter = None
 
     def shutdown(self):
@@ -81,9 +77,9 @@ class EynollahProcessor(Processor):
             image_filename = "dummy" # will be replaced by ocrd.Processor.process_page_file
             result.images.append(OcrdPageResultImage(page_image, '.IMG', page)) # mark as new original
         # FIXME: mask out already existing regions (incremental segmentation)
-        self.eynollah.image_filename = image_filename
-        self.eynollah._imgs = self.eynollah._cache_images(
-            image_pil=page_image
+        self.eynollah.cache_images(
+            image_pil=page_image,
+            dpi=self.parameter['dpi'],
         )
         self.eynollah.writer = EynollahXmlWriter(
             dir_out=None,
@@ -91,5 +87,5 @@ class EynollahProcessor(Processor):
             curved_line=self.eynollah.curved_line,
             textline_light=self.eynollah.textline_light,
             pcgts=pcgts)
-        self.eynollah.run()
+        self.eynollah.run_single()
         return result

--- a/src/eynollah/sbb_binarize.py
+++ b/src/eynollah/sbb_binarize.py
@@ -4,24 +4,18 @@ Tool to load model and binarize a given image.
 
 import sys
 from glob import glob
-from os import environ, devnull
-from os.path import join
-from warnings import catch_warnings, simplefilter
 import os
+import logging
 
 import numpy as np
 from PIL import Image
 import cv2
-environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-stderr = sys.stderr
-sys.stderr = open(devnull, 'w')
+from ocrd_utils import tf_disable_interactive_logs
+tf_disable_interactive_logs()
 import tensorflow as tf
 from tensorflow.keras.models import load_model
 from tensorflow.python.keras import backend as tensorflow_backend
-sys.stderr = stderr
 
-
-import logging
 
 def resize_image(img_in, input_height, input_width):
     return cv2.resize(img_in, (input_width, input_height), interpolation=cv2.INTER_NEAREST)
@@ -53,7 +47,7 @@ class SbbBinarizer:
         del self.session
 
     def load_model(self, model_name):
-        model = load_model(join(self.model_dir, model_name), compile=False)
+        model = load_model(os.path.join(self.model_dir, model_name), compile=False)
         model_height = model.layers[len(model.layers)-1].output_shape[1]
         model_width = model.layers[len(model.layers)-1].output_shape[2]
         n_classes = model.layers[len(model.layers)-1].output_shape[3]

--- a/src/eynollah/utils/contour.py
+++ b/src/eynollah/utils/contour.py
@@ -247,7 +247,7 @@ def get_textregion_contours_in_org_image_light(cnts, img, slope_first, map=map):
     img = cv2.resize(img, (int(img.shape[1]/6), int(img.shape[0]/6)), interpolation=cv2.INTER_NEAREST)
     ##cnts = list( (np.array(cnts)/2).astype(np.int16) )
     #cnts = cnts/2
-    cnts = [(i/6).astype(np.int) for i in cnts]
+    cnts = [(i/6).astype(int) for i in cnts]
     results = map(partial(do_back_rotation_and_get_cnt_back,
                           img=img,
                           slope_first=slope_first,

--- a/src/eynollah/utils/pil_cv2.py
+++ b/src/eynollah/utils/pil_cv2.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from PIL import Image
 import numpy as np
 from ocrd_models import OcrdExif
@@ -17,12 +18,13 @@ def pil2cv(img):
 def check_dpi(img):
     try:
         if isinstance(img, Image.Image):
-            pil_image = img
+            pil_image = nullcontext(img)
         elif isinstance(img, str):
             pil_image = Image.open(img)
         else:
-            pil_image = cv2pil(img)
-        exif = OcrdExif(pil_image)
+            pil_image = nullcontext(cv2pil(img))
+        with pil_image:
+            exif = OcrdExif(pil_image)
         resolution = exif.resolution
         if resolution == 1:
             raise Exception()

--- a/src/eynollah/utils/separate_lines.py
+++ b/src/eynollah/utils/separate_lines.py
@@ -1616,7 +1616,7 @@ def do_work_of_slopes_new(
             textline_con_fil = filter_contours_area_of_image(img_int_p, textline_con,
                                                              hierarchy,
                                                              max_area=1, min_area=0.00008)
-            y_diff_mean = find_contours_mean_y_diff(textline_con_fil)
+            y_diff_mean = find_contours_mean_y_diff(textline_con_fil) if len(textline_con_fil) > 1 else np.NaN
             if np.isnan(y_diff_mean):
                 slope_for_all = MAX_SLOPE
             else:

--- a/src/eynollah/utils/separate_lines.py
+++ b/src/eynollah/utils/separate_lines.py
@@ -1681,7 +1681,7 @@ def do_work_of_slopes_new_curved(
             textline_con_fil = filter_contours_area_of_image(img_int_p, textline_con,
                                                              hierarchy,
                                                              max_area=1, min_area=0.0008)
-            y_diff_mean = find_contours_mean_y_diff(textline_con_fil)
+            y_diff_mean = find_contours_mean_y_diff(textline_con_fil) if len(textline_con_fil) > 1 else np.NaN
             if np.isnan(y_diff_mean):
                 slope_for_all = MAX_SLOPE
             else:


### PR DESCRIPTION
In order to simplify both the standalone CLI and OCR-D interface, this restructures the "outer" code as follows:
- no more data passing to the constructor (image_filename, image_pil, dir_in, pcgts etc) – just pure model loading
- no more `start_new_session_and_load` stuff – this was entirely redundant (since the time `dir_in` mode got introduced)
- no more `dir_in` attribute; instead, add `dir_in` (and `overwrite`) as kwargs to `run()` (besides `image_filename`) and differentiate there
- separate the main image loop's body out of `run()` into `run_single()` (independent of the mode)
- expose `cache_images()` as public, write directly to `_imgs` attr; also add kwarg `dpi` (instead of `override_dpi` attr)
- OCR-D: instantiate Eynollah during `setup` already, and just once; re-use it per page via `cache_images` and by instantiating a new `.writer` for the input `pcgts`

This builds on #148 and is meant to be merged there – **if** you find it useful @vahidrezanezhad @cneud @kba.

The overall diff (`Files changed`) is not likely to be useful for reviewing here. Instead, I recommend either browsing the final code result or going commit by commit.
