### PR TITLE
refactoring for 192: speedup and improvements

### DIFF
--- a/.github/workflows/test-eynollah.yml
+++ b/.github/workflows/test-eynollah.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         make install-dev EXTRAS=OCR,plotting
-        make deps-test
+        make deps-test EXTRAS=OCR,plotting
     - name: Test with pytest
       run: make coverage PYTEST_ARGS="-vv --junitxml=pytest.xml"
     - name: Get coverage results

--- a/.github/workflows/test-eynollah.yml
+++ b/.github/workflows/test-eynollah.yml
@@ -67,6 +67,10 @@ jobs:
         make install-dev EXTRAS=OCR,plotting
         make deps-test EXTRAS=OCR,plotting
         ls -l models_*
+    - name: Lint with ruff
+      uses: astral-sh/ruff-action@v3
+      with:
+        src: "./src"
     - name: Test with pytest
       run: make coverage PYTEST_ARGS="-vv --junitxml=pytest.xml"
     - name: Get coverage results

--- a/.github/workflows/test-eynollah.yml
+++ b/.github/workflows/test-eynollah.yml
@@ -66,6 +66,7 @@ jobs:
         python -m pip install --upgrade pip
         make install-dev EXTRAS=OCR,plotting
         make deps-test EXTRAS=OCR,plotting
+        ls -l models_*
     - name: Test with pytest
       run: make coverage PYTEST_ARGS="-vv --junitxml=pytest.xml"
     - name: Get coverage results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,16 @@ Fixed:
  * `get_smallest_skew`: after shifting search range of rotation angle, use overall best result
  * Dockerfile: fix CUDA installation (cuDNN contested between Torch and TF due to extra OCR)
  * OCR: re-instate missing methods and fix `utils_ocr` function calls
+ * mbreorder/enhancement CLIs: missing imports
  * :fire: writer: `SeparatorRegion` needs `SeparatorRegionType` (not `ImageRegionType`)
 f458e3e
  * tests: switch from `pytest-subtests` to `parametrize` so we can use `pytest-isolate`
    (so CUDA memory gets freed between tests if running on GPU)
+
+Added:
+ * test coverage for OCR options in `layout`
+ * test coverage for table detection in `layout`
+ * CI linting with ruff
 
 Changed:
  
@@ -28,7 +34,19 @@ Changed:
    but use shared memory if necessary, and switch back from `loky` to stdlib,
    and shutdown in `del()` instead of `atexit`
  * :fire: OCR: switch CNN-RNN model to `20250930` version compatible with TF 2.12 on CPU, too
+ * OCR: allow running `-tr` without `-fl`, too
  * :fire: writer: use `@type='heading'` instead of `'header'` for headings
+ * :fire: performance gains via refactoring (simplification, less copy-code, vectorization,
+   avoiding unused calculations, avoiding unnecessary 3-channel image operations)
+ * :fire: heuristic reading order detection: many improvements
+    - contour vs splitter box matching: 
+      * contour must be contained in box exactly instead of heuristics
+      * make fallback center matching, center must be contained in box
+    - original vs deskewed contour matching:
+      * same min-area filter on both sides
+      * similar area score in addition to center proximity
+      * avoid duplicate and missing mappings by allowing N:M
+        matches and splitting+joining where necessary
  * CI: update+improve model caching
 
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ help:
 # Download and extract models to $(PWD)/models_layout_v0_5_0
 models: $(BIN_MODELNAME) $(SEG_MODELNAME) $(OCR_MODELNAME)
 
+# do not download these files if we already have the directories
+.INTERMEDIATE: $(BIN_MODELFILE) $(SEG_MODELFILE) $(OCR_MODELFILE)
+
 $(BIN_MODELFILE):
 	wget -O $@ $(BIN_MODEL)
 $(SEG_MODELFILE):

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ endif
 deps-test: $(BIN_MODELNAME) $(SEG_MODELNAME)
 	$(PIP) install -r requirements-test.txt
 ifeq (OCR,$(findstring OCR, $(EXTRAS)))
-	ln -s $(OCR_MODELNAME)/* $(SEG_MODELNAME)/
+	ln -rs $(OCR_MODELNAME)/* $(SEG_MODELNAME)/
 endif
 
 smoke-test: TMPDIR != mktemp -d

--- a/Makefile
+++ b/Makefile
@@ -90,26 +90,29 @@ deps-test: $(OCR_MODELNAME)
 endif
 deps-test: $(BIN_MODELNAME) $(SEG_MODELNAME)
 	$(PIP) install -r requirements-test.txt
+ifeq (OCR,$(findstring OCR, $(EXTRAS)))
+	ln -s $(OCR_MODELNAME)/* $(SEG_MODELNAME)/
+endif
 
 smoke-test: TMPDIR != mktemp -d
 smoke-test: tests/resources/kant_aufklaerung_1784_0020.tif
 	# layout analysis:
-	eynollah layout -i $< -o $(TMPDIR) -m $(CURDIR)/models_layout_v0_5_0
+	eynollah layout -i $< -o $(TMPDIR) -m $(CURDIR)/$(SEG_MODELNAME)
 	fgrep -q http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 $(TMPDIR)/$(basename $(<F)).xml
 	fgrep -c -e TextRegion -e ImageRegion -e SeparatorRegion $(TMPDIR)/$(basename $(<F)).xml
 	# layout, directory mode (skip one, add one):
-	eynollah layout -di $(<D) -o $(TMPDIR) -m $(CURDIR)/models_layout_v0_5_0
+	eynollah layout -di $(<D) -o $(TMPDIR) -m $(CURDIR)/$(SEG_MODELNAME)
 	test -s $(TMPDIR)/euler_rechenkunst01_1738_0025.xml
 	# mbreorder, directory mode (overwrite):
-	eynollah machine-based-reading-order -di $(<D) -o $(TMPDIR) -m $(CURDIR)/models_layout_v0_5_0
+	eynollah machine-based-reading-order -di $(<D) -o $(TMPDIR) -m $(CURDIR)/$(SEG_MODELNAME)
 	fgrep -q http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 $(TMPDIR)/$(basename $(<F)).xml
 	fgrep -c -e RegionRefIndexed $(TMPDIR)/$(basename $(<F)).xml
 	# binarize:
-	eynollah binarization -m $(CURDIR)/default-2021-03-09 -i $< -o $(TMPDIR)/$(<F)
+	eynollah binarization -m $(CURDIR)/$(BIN_MODELNAME) -i $< -o $(TMPDIR)/$(<F)
 	test -s $(TMPDIR)/$(<F)
 	@set -x; test "$$(identify -format '%w %h' $<)" = "$$(identify -format '%w %h' $(TMPDIR)/$(<F))"
 	# enhance:
-	eynollah enhancement -m $(CURDIR)/models_layout_v0_5_0 -sos -i $< -o $(TMPDIR) -O
+	eynollah enhancement -m $(CURDIR)/$(SEG_MODELNAME) -sos -i $< -o $(TMPDIR) -O
 	test -s $(TMPDIR)/$(<F)
 	@set -x; test "$$(identify -format '%w %h' $<)" = "$$(identify -format '%w %h' $(TMPDIR)/$(<F))"
 	$(RM) -r $(TMPDIR)
@@ -120,12 +123,12 @@ ocrd-test: tests/resources/kant_aufklaerung_1784_0020.tif
 	cp $< $(TMPDIR)
 	ocrd workspace -d $(TMPDIR) init
 	ocrd workspace -d $(TMPDIR) add -G OCR-D-IMG -g PHYS_0020 -i OCR-D-IMG_0020 $(<F)
-	ocrd-eynollah-segment -w $(TMPDIR) -I OCR-D-IMG -O OCR-D-SEG -P models $(CURDIR)/models_layout_v0_5_0
+	ocrd-eynollah-segment -w $(TMPDIR) -I OCR-D-IMG -O OCR-D-SEG -P models $(CURDIR)/$(SEG_MODELNAME)
 	result=$$(ocrd workspace -d $(TMPDIR) find -G OCR-D-SEG); \
 	fgrep -q http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 $(TMPDIR)/$$result && \
 	fgrep -c -e TextRegion -e ImageRegion -e SeparatorRegion $(TMPDIR)/$$result
-	ocrd-sbb-binarize -w $(TMPDIR) -I OCR-D-IMG -O OCR-D-BIN -P model $(CURDIR)/default-2021-03-09
-	ocrd-sbb-binarize -w $(TMPDIR) -I OCR-D-SEG -O OCR-D-SEG-BIN -P model $(CURDIR)/default-2021-03-09 -P operation_level region
+	ocrd-sbb-binarize -w $(TMPDIR) -I OCR-D-IMG -O OCR-D-BIN -P model $(CURDIR)/$(BIN_MODELNAME)
+	ocrd-sbb-binarize -w $(TMPDIR) -I OCR-D-SEG -O OCR-D-SEG-BIN -P model $(CURDIR)/$(BIN_MODELNAME) -P operation_level region
 	$(RM) -r $(TMPDIR)
 
 # Run unit tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,6 @@ ignore = [
 # disable bare except
 "E722",
 ]
+
+[tool.ruff.format]
+quote-style = "preserve"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,18 @@ where = ["src"]
 [tool.coverage.run]
 branch = true
 source = ["eynollah"]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+ignore = [
+# disable unused imports
+"F401",
+# disable import order
+"E402",
+# disable unused variables
+"F841",
+# disable bare except
+"E722",
+]

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4726,8 +4726,8 @@ class Eynollah:
             txt_con_org , conf_contours_textregions = get_textregion_contours_in_org_image_light(
                 contours_only_text_parent, self.image, confidence_matrix)
         #print("text region early 4 in %.1fs", time.time() - t0)
-        boxes_text, _ = get_text_region_boxes_by_given_contours(contours_only_text_parent)
-        boxes_marginals, _ = get_text_region_boxes_by_given_contours(polygons_of_marginals)
+        boxes_text = get_text_region_boxes_by_given_contours(contours_only_text_parent)
+        boxes_marginals = get_text_region_boxes_by_given_contours(polygons_of_marginals)
         #print("text region early 5 in %.1fs", time.time() - t0)
         ## birdan sora chock chakir
         if not self.curved_line:

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -79,7 +79,6 @@ from .utils.contour import (
     get_textregion_contours_in_org_image_light,
     return_contours_of_image,
     return_contours_of_interested_region,
-    return_contours_of_interested_region_by_min_size,
     return_contours_of_interested_textline,
     return_parent_contours,
     dilate_textregion_contours,
@@ -4242,14 +4241,11 @@ class Eynollah:
             all_found_textline_polygons = filter_contours_area_of_image(
                 textline_mask_tot_ea, cnt_clean_rot_raw, hir_on_cnt_clean_rot, max_area=1, min_area=0.00001)
             
-            M_main_tot = [cv2.moments(all_found_textline_polygons[j])
-                        for j in range(len(all_found_textline_polygons))]
-            w_h_textlines = [cv2.boundingRect(all_found_textline_polygons[j])[2:]
-                             for j in range(len(all_found_textline_polygons))]
-            w_h_textlines = [w_h_textlines[j][0] / float(w_h_textlines[j][1]) for j in range(len(w_h_textlines))]
-            cx_main_tot = [(M_main_tot[j]["m10"] / (M_main_tot[j]["m00"] + 1e-32)) for j in range(len(M_main_tot))]
-            cy_main_tot = [(M_main_tot[j]["m01"] / (M_main_tot[j]["m00"] + 1e-32)) for j in range(len(M_main_tot))]
-            
+            cx_main_tot, cy_main_tot = find_center_of_contours(all_found_textline_polygons)
+            w_h_textlines = [cv2.boundingRect(polygon)[2:]
+                             for polygon in all_found_textline_polygons]
+            w_h_textlines = [w / float(h) for w, h in w_h_textlines]
+
             all_found_textline_polygons = self.get_textlines_of_a_textregion_sorted(
                 #all_found_textline_polygons[::-1]
                 all_found_textline_polygons, cx_main_tot, cy_main_tot, w_h_textlines)
@@ -4677,7 +4673,8 @@ class Eynollah:
                 self.plotter.save_plot_of_layout_all(text_regions_p, image_page)
 
             label_img = 4
-            polygons_of_drop_capitals = return_contours_of_interested_region_by_min_size(text_regions_p, label_img)
+            polygons_of_drop_capitals = return_contours_of_interested_region(text_regions_p, label_img,
+                                                                             min_area=0.00003)
             ##all_found_textline_polygons = adhere_drop_capital_region_into_corresponding_textline(
                 ##text_regions_p, polygons_of_drop_capitals, contours_only_text_parent, contours_only_text_parent_h,
                 ##all_box_coord, all_box_coord_h, all_found_textline_polygons, all_found_textline_polygons_h,

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4610,7 +4610,11 @@ class Eynollah:
                     for i in range(len(contours_only_text_parent)):
                         p = np.dot(M_22, centers[:, i:i+1]) # [2, 1]
                         p -= offset
-                        dists = np.linalg.norm(p - centers_d, axis=0)
+                        # add dimension for area
+                        #dists = np.linalg.norm(p - centers_d, axis=0)
+                        diffs = (np.append(p, [[areas_cnt_text_parent[i]]], axis=0) -
+                                 np.append(centers_d, areas_cnt_text_d[np.newaxis], axis=0))
+                        dists = np.linalg.norm(diffs, axis=0)
                         contours_only_text_parent_d_ordered.append(
                             contours_only_text_parent_d[np.argmin(dists)])
                         # cv2.fillPoly(img2, pts=[contours_only_text_parent_d[np.argmin(dists)]], color=i + 1)

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4418,52 +4418,53 @@ class Eynollah:
     def separate_marginals_to_left_and_right_and_order_from_top_to_down(
             self, polygons_of_marginals, all_found_textline_polygons_marginals, all_box_coord_marginals,
             slopes_marginals, mid_point_of_page_width):
-        cx_marg, cy_marg, _, _, _, _, _ = find_new_features_of_contours(
-            polygons_of_marginals)
-        
+        cx_marg, cy_marg = find_center_of_contours(polygons_of_marginals)
         cx_marg = np.array(cx_marg)
         cy_marg = np.array(cy_marg)
+
+        def split(lis):
+            array = np.array(lis)
+            return (list(array[cx_marg < mid_point_of_page_width]),
+                    list(array[cx_marg >= mid_point_of_page_width]))
+
+        (poly_marg_left,
+         poly_marg_right) = \
+             split(polygons_of_marginals)
+
+        (all_found_textline_polygons_marginals_left,
+         all_found_textline_polygons_marginals_right) = \
+            split(all_found_textline_polygons_marginals)
         
-        poly_marg_left = list( np.array(polygons_of_marginals)[cx_marg < mid_point_of_page_width] )
-        poly_marg_right = list( np.array(polygons_of_marginals)[cx_marg >= mid_point_of_page_width] )
+        (all_box_coord_marginals_left,
+         all_box_coord_marginals_right) = \
+             split(all_box_coord_marginals)
         
-        all_found_textline_polygons_marginals_left = \
-            list( np.array(all_found_textline_polygons_marginals)[cx_marg < mid_point_of_page_width] )
-        all_found_textline_polygons_marginals_right = \
-            list( np.array(all_found_textline_polygons_marginals)[cx_marg >= mid_point_of_page_width] )
+        (slopes_marg_left,
+         slopes_marg_right) = \
+             split(slopes_marginals)
         
-        all_box_coord_marginals_left = list( np.array(all_box_coord_marginals)[cx_marg < mid_point_of_page_width] )
-        all_box_coord_marginals_right = list( np.array(all_box_coord_marginals)[cx_marg >= mid_point_of_page_width] )
+        (cy_marg_left,
+         cy_marg_right) = \
+             split(cy_marg)
+
+        order_left = np.argsort(cy_marg_left)
+        order_right = np.argsort(cy_marg_right)
+        def sort_left(lis):
+            return list(np.array(lis)[order_left])
+        def sort_right(lis):
+            return list(np.array(lis)[order_right])
         
-        slopes_marg_left = list( np.array(slopes_marginals)[cx_marg < mid_point_of_page_width] )
-        slopes_marg_right = list( np.array(slopes_marginals)[cx_marg >= mid_point_of_page_width] )
+        ordered_left_marginals = sort_left(poly_marg_left)
+        ordered_right_marginals = sort_right(poly_marg_right)
         
-        cy_marg_left = cy_marg[cx_marg < mid_point_of_page_width]
-        cy_marg_right = cy_marg[cx_marg >= mid_point_of_page_width]
+        ordered_left_marginals_textline = sort_left(all_found_textline_polygons_marginals_left)
+        ordered_right_marginals_textline = sort_right(all_found_textline_polygons_marginals_right)
         
-        ordered_left_marginals = [poly for _, poly in sorted(zip(cy_marg_left, poly_marg_left),
-                                                             key=lambda x: x[0])]
-        ordered_right_marginals = [poly for _, poly in sorted(zip(cy_marg_right, poly_marg_right),
-                                                              key=lambda x: x[0])]
+        ordered_left_marginals_bbox = sort_left(all_box_coord_marginals_left)
+        ordered_right_marginals_bbox = sort_right(all_box_coord_marginals_right)
         
-        ordered_left_marginals_textline = [poly for _, poly in sorted(zip(cy_marg_left,
-                                                                          all_found_textline_polygons_marginals_left),
-                                                                      key=lambda x: x[0])]
-        ordered_right_marginals_textline = [poly for _, poly in sorted(zip(cy_marg_right,
-                                                                           all_found_textline_polygons_marginals_right),
-                                                                       key=lambda x: x[0])]
-        
-        ordered_left_marginals_bbox = [poly for _, poly in sorted(zip(cy_marg_left,
-                                                                      all_box_coord_marginals_left),
-                                                                  key=lambda x: x[0])]
-        ordered_right_marginals_bbox = [poly for _, poly in sorted(zip(cy_marg_right,
-                                                                       all_box_coord_marginals_right),
-                                                                   key=lambda x: x[0])]
-        
-        ordered_left_slopes_marginals = [poly for _, poly in sorted(zip(cy_marg_left, slopes_marg_left),
-                                                                    key=lambda x: x[0])]
-        ordered_right_slopes_marginals = [poly for _, poly in sorted(zip(cy_marg_right, slopes_marg_right),
-                                                                     key=lambda x: x[0])]
+        ordered_left_slopes_marginals = sort_left(slopes_marg_left)
+        ordered_right_slopes_marginals = sort_right(slopes_marg_right)
         
         return (ordered_left_marginals,
                 ordered_right_marginals,

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4559,7 +4559,6 @@ class Eynollah:
             areas_cnt_text = np.array([cv2.contourArea(c) for c in contours_only_text_parent])
             areas_cnt_text = areas_cnt_text / float(text_only.shape[0] * text_only.shape[1])
             #self.logger.info('areas_cnt_text %s', areas_cnt_text)
-            contour0 = contours_only_text_parent[np.argmax(areas_cnt_text)]
             contours_only_text_parent = np.array(contours_only_text_parent)[areas_cnt_text > MIN_AREA_REGION]
             areas_cnt_text_parent = areas_cnt_text[areas_cnt_text > MIN_AREA_REGION]
 
@@ -4567,8 +4566,10 @@ class Eynollah:
             contours_only_text_parent = contours_only_text_parent[index_con_parents]
             areas_cnt_text_parent = areas_cnt_text_parent[index_con_parents]
 
-            center0 = np.stack(find_center_of_contours([contour0])) # [2, 1]
             centers = np.stack(find_center_of_contours(contours_only_text_parent)) # [2, N]
+
+            contour0 = contours_only_text_parent[-1]
+            center0 = centers[:, -1:] # [2, 1]
 
             if np.abs(slope_deskew) >= SLOPE_THRESHOLD:
                 contours_only_text_d, hir_on_text_d = return_contours_of_image(text_only_d)
@@ -4578,17 +4579,15 @@ class Eynollah:
                 areas_cnt_text_d = areas_cnt_text_d / float(text_only_d.shape[0] * text_only_d.shape[1])
 
                 if len(contours_only_text_parent_d):
-                    contour0_d = contours_only_text_parent_d[np.argmax(areas_cnt_text_d)]
                     index_con_parents_d = np.argsort(areas_cnt_text_d)
                     contours_only_text_parent_d = np.array(contours_only_text_parent_d)[index_con_parents_d]
-                    # rs: should be the same, no?
-                    assert np.all(contour0_d == contours_only_text_parent_d[-1]), (np.argmax(areas_cnt_text_d), index_con_parents_d[-1])
                     areas_cnt_text_d = areas_cnt_text_d[index_con_parents_d]
 
-                    center0_d = np.stack(find_center_of_contours([contour0_d])) # [2, 1]
                     centers_d = np.stack(find_center_of_contours(contours_only_text_parent_d)) # [2, N]
-                    # rs: should be the same, no?
-                    assert center0_d[0,0] == centers_d[0,-1] and center0_d[1,0] == centers_d[1,-1]
+
+                    contour0_d = contours_only_text_parent_d[-1]
+                    center0_d = centers_d[:, -1:] # [2, 1]
+
                     last5_centers_d = centers_d[:, -5:]
                     dists_d = np.linalg.norm(center0 - last5_centers_d, axis=0)
                     ind_largest = len(contours_only_text_parent_d) - last5_centers_d.shape[1] + np.argmin(dists_d)

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -70,6 +70,7 @@ from .utils.contour import (
     filter_contours_area_of_image,
     filter_contours_area_of_image_tables,
     find_contours_mean_y_diff,
+    find_center_of_contours,
     find_new_features_of_contours,
     find_features_of_contours,
     get_text_region_boxes_by_given_contours,
@@ -1859,14 +1860,10 @@ class Eynollah:
     def get_slopes_and_deskew_new_light2(self, contours, contours_par, textline_mask_tot, boxes, slope_deskew):
 
         polygons_of_textlines = return_contours_of_interested_region(textline_mask_tot,1,0.00001)
-        M_main_tot = [cv2.moments(polygons_of_textlines[j])
-                      for j in range(len(polygons_of_textlines))]
+        cx_main_tot, cy_main_tot = find_center_of_contours(polygons_of_textlines)
+        w_h_textlines = [cv2.boundingRect(polygon)[2:] for polygon in polygons_of_textlines]
 
-        w_h_textlines = [cv2.boundingRect(polygons_of_textlines[i])[2:] for i in range(len(polygons_of_textlines))]
-        cx_main_tot = [(M_main_tot[j]["m10"] / (M_main_tot[j]["m00"] + 1e-32)) for j in range(len(M_main_tot))]
-        cy_main_tot = [(M_main_tot[j]["m01"] / (M_main_tot[j]["m00"] + 1e-32)) for j in range(len(M_main_tot))]
-
-        args_textlines = np.array(range(len(polygons_of_textlines)))
+        args_textlines = np.arange(len(polygons_of_textlines))
         all_found_textline_polygons = []
         slopes = []
         all_box_coord =[]
@@ -4809,8 +4806,8 @@ class Eynollah:
             areas_cnt_text_parent = self.return_list_of_contours_with_desired_order(
                 areas_cnt_text_parent, index_con_parents)
 
-            cx_bigest_big, cy_biggest_big, _, _, _, _, _ = find_new_features_of_contours([contours_biggest])
-            cx_bigest, cy_biggest, _, _, _, _, _ = find_new_features_of_contours(contours_only_text_parent)
+            cx_bigest_big, cy_biggest_big = find_center_of_contours([contours_biggest])
+            cx_bigest, cy_biggest = find_center_of_contours(contours_only_text_parent)
 
             if np.abs(slope_deskew) >= SLOPE_THRESHOLD:
                 contours_only_text_d, hir_on_text_d = return_contours_of_image(text_only_d)
@@ -4834,10 +4831,8 @@ class Eynollah:
                     areas_cnt_text_d = self.return_list_of_contours_with_desired_order(
                         areas_cnt_text_d, index_con_parents_d)
 
-                    cx_bigest_d_big, cy_biggest_d_big, _, _, _, _, _ = \
-                        find_new_features_of_contours([contours_biggest_d])
-                    cx_bigest_d, cy_biggest_d, _, _, _, _, _ = \
-                        find_new_features_of_contours(contours_only_text_parent_d)
+                    cx_bigest_d_big, cy_biggest_d_big = find_center_of_contours([contours_biggest_d])
+                    cx_bigest_d, cy_biggest_d = find_center_of_contours(contours_only_text_parent_d)
                     try:
                         if len(cx_bigest_d) >= 5:
                             cx_bigest_d_last5 = cx_bigest_d[-5:]

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -108,7 +108,6 @@ from .utils.utils_ocr import (
     get_contours_and_bounding_boxes
 )
 from .utils.separate_lines import (
-    textline_contours_postprocessing,
     separate_lines_new2,
     return_deskew_slop,
     do_work_of_slopes_new,
@@ -2061,43 +2060,6 @@ class Eynollah:
         return ((prediction_textline[:, :, 0]==1).astype(np.uint8),
                 (prediction_textline_longshot_true_size[:, :, 0]==1).astype(np.uint8))
 
-
-    def do_work_of_slopes(self, q, poly, box_sub, boxes_per_process, textline_mask_tot, contours_per_process):
-        self.logger.debug('enter do_work_of_slopes')
-        slope_biggest = 0
-        slopes_sub = []
-        boxes_sub_new = []
-        poly_sub = []
-        for mv in range(len(boxes_per_process)):
-            crop_img, _ = crop_image_inside_box(boxes_per_process[mv], textline_mask_tot)
-            crop_img = cv2.erode(crop_img, KERNEL, iterations=2)
-            try:
-                textline_con, hierarchy = return_contours_of_image(crop_img)
-                textline_con_fil = filter_contours_area_of_image(crop_img, textline_con, hierarchy,
-                                                                 max_area=1, min_area=0.0008)
-                y_diff_mean = find_contours_mean_y_diff(textline_con_fil)
-                sigma_des = max(1, int(y_diff_mean * (4.0 / 40.0)))
-                crop_img[crop_img > 0] = 1
-                slope_corresponding_textregion = return_deskew_slop(crop_img, sigma_des,
-                                                                    logger=self.logger, plotter=self.plotter)
-            except Exception as why:
-                self.logger.error(why)
-                slope_corresponding_textregion = MAX_SLOPE
-
-            if slope_corresponding_textregion == MAX_SLOPE:
-                slope_corresponding_textregion = slope_biggest
-            slopes_sub.append(slope_corresponding_textregion)
-
-            cnt_clean_rot = textline_contours_postprocessing(
-                crop_img, slope_corresponding_textregion, contours_per_process[mv], boxes_per_process[mv])
-
-            poly_sub.append(cnt_clean_rot)
-            boxes_sub_new.append(boxes_per_process[mv])
-
-        q.put(slopes_sub)
-        poly.put(poly_sub)
-        box_sub.put(boxes_sub_new)
-        self.logger.debug('exit do_work_of_slopes')
 
     def get_regions_light_v_extract_only_images(self,img,is_image_enhanced, num_col_classifier):
         self.logger.debug("enter get_regions_extract_images_only")

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4437,6 +4437,8 @@ class Eynollah:
         ###min_con_area = 0.000005
         contours_only_text, hir_on_text = return_contours_of_image(text_only)
         contours_only_text_parent = return_parent_contours(contours_only_text, hir_on_text)
+        contours_only_text_parent_d_ordered = []
+        contours_only_text_parent_d = []
         if len(contours_only_text_parent) > 0:
             areas_tot_text = np.prod(text_only.shape)
             areas_cnt_text = np.array([cv2.contourArea(c) for c in contours_only_text_parent])
@@ -4558,15 +4560,6 @@ class Eynollah:
                     # plt.subplot(2, 2, 2, title="result contours")
                     # plt.imshow(img4)
                     # plt.show()
-                else:
-                    contours_only_text_parent_d_ordered = []
-                    contours_only_text_parent_d = []
-                    contours_only_text_parent = []
-
-            else:
-                contours_only_text_parent_d_ordered = []
-                contours_only_text_parent_d = []
-                #contours_only_text_parent = []
 
         if not len(contours_only_text_parent):
             # stop early
@@ -4684,11 +4677,6 @@ class Eynollah:
                  slopes_marginals, mid_point_of_page_width)
         
         #print(len(polygons_of_marginals), len(ordered_left_marginals), len(ordered_right_marginals), 'marginals ordred')
-        if np.abs(slope_deskew) >= SLOPE_THRESHOLD:
-            contours_only_text_parent_d_ordered = self.return_list_of_contours_with_desired_order(
-                contours_only_text_parent_d_ordered, index_by_text_par_con)
-        else:
-            contours_only_text_parent_d_ordered = None
 
         if self.full_layout:
             if self.light_version:

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4726,7 +4726,6 @@ class Eynollah:
             self.plotter.write_images_into_directory(polygons_of_images, image_page)
         t_order = time.time()
 
-        #if self.full_layout:
         self.logger.info("Step 4/5: Reading Order Detection")
 
         if self.reading_order_machine_based:
@@ -4749,46 +4748,41 @@ class Eynollah:
                     boxes_d, textline_mask_tot_d)
         self.logger.info(f"Detection of reading order took {time.time() - t_order:.1f}s")
 
+        ocr_all_textlines = None
+        ocr_all_textlines_marginals_left = None
+        ocr_all_textlines_marginals_right = None
+        ocr_all_textlines_h = None
+        ocr_all_textlines_drop = None
         if self.ocr:
             self.logger.info("Step 4.5/5: OCR Processing")
 
             if not self.tr:
                 gc.collect()
 
-                if len(all_found_textline_polygons)>0:
+                if len(all_found_textline_polygons):
                     ocr_all_textlines = return_rnn_cnn_ocr_of_given_textlines(
                         image_page, all_found_textline_polygons, all_box_coord,
                         self.prediction_model, self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
-                else:
-                    ocr_all_textlines = None
                     
-                if all_found_textline_polygons_marginals_left and len(all_found_textline_polygons_marginals_left)>0:
+                if len(all_found_textline_polygons_marginals_left):
                     ocr_all_textlines_marginals_left = return_rnn_cnn_ocr_of_given_textlines(
                         image_page, all_found_textline_polygons_marginals_left, all_box_coord_marginals_left,
                         self.prediction_model, self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
-                else:
-                    ocr_all_textlines_marginals_left = None
                     
-                if all_found_textline_polygons_marginals_right and len(all_found_textline_polygons_marginals_right)>0:
+                if len(all_found_textline_polygons_marginals_right):
                     ocr_all_textlines_marginals_right = return_rnn_cnn_ocr_of_given_textlines(
                         image_page, all_found_textline_polygons_marginals_right, all_box_coord_marginals_right,
                         self.prediction_model, self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
-                else:
-                    ocr_all_textlines_marginals_right = None
                 
-                if all_found_textline_polygons_h and len(all_found_textline_polygons)>0:
+                if self.full_layout and len(all_found_textline_polygons):
                     ocr_all_textlines_h = return_rnn_cnn_ocr_of_given_textlines(
                         image_page, all_found_textline_polygons_h, all_box_coord_h,
                         self.prediction_model, self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
-                else:
-                    ocr_all_textlines_h = None
                     
-                if polygons_of_drop_capitals and len(polygons_of_drop_capitals)>0:
+                if self.full_layout and len(polygons_of_drop_capitals):
                     ocr_all_textlines_drop = return_rnn_cnn_ocr_of_given_textlines(
                         image_page, polygons_of_drop_capitals, np.zeros((len(polygons_of_drop_capitals), 4)),
                         self.prediction_model, self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
-                else:
-                    ocr_all_textlines_drop = None
 
             else:
                 if self.light_version:
@@ -4805,6 +4799,7 @@ class Eynollah:
                 ind_tot = 0
                 #cv2.imwrite('./img_out.png', image_page)
                 ocr_all_textlines = []
+                # FIXME: what about lines in marginals / headings / drop-capitals here?
                 for indexing, ind_poly_first in enumerate(all_found_textline_polygons):
                     ocr_textline_in_textregion = []
                     for indexing2, ind_poly in enumerate(ind_poly_first):
@@ -4840,12 +4835,6 @@ class Eynollah:
                         ocr_textline_in_textregion.append(text_ocr)
                         ind_tot = ind_tot +1
                     ocr_all_textlines.append(ocr_textline_in_textregion)
-        else:
-            ocr_all_textlines = None
-            ocr_all_textlines_marginals_left = None
-            ocr_all_textlines_marginals_right = None
-            ocr_all_textlines_h = None
-            ocr_all_textlines_drop = None
                 
         self.logger.info("Step 5/5: Output Generation")
 

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4040,79 +4040,23 @@ class Eynollah:
             self, contours, text_con_org, contours_textline,
             contours_only_text_parent_d_ordered,
             conf_contours_textregions):
-        ###contours_txtline_of_all_textregions = []
-        ###for jj in range(len(contours_textline)):
-            ###contours_txtline_of_all_textregions = contours_txtline_of_all_textregions + contours_textline[jj]
 
-        ###M_main_textline = [cv2.moments(contours_txtline_of_all_textregions[j])
-        ###                   for j in range(len(contours_txtline_of_all_textregions))]
-        ###cx_main_textline = [(M_main_textline[j]["m10"] / (M_main_textline[j]["m00"] + 1e-32))
-        ###                    for j in range(len(M_main_textline))]
-        ###cy_main_textline = [(M_main_textline[j]["m01"] / (M_main_textline[j]["m00"] + 1e-32))
-        ###                    for j in range(len(M_main_textline))]
-
-        ###M_main = [cv2.moments(contours[j]) for j in range(len(contours))]
-        ###cx_main = [(M_main[j]["m10"] / (M_main[j]["m00"] + 1e-32)) for j in range(len(M_main))]
-        ###cy_main = [(M_main[j]["m01"] / (M_main[j]["m00"] + 1e-32)) for j in range(len(M_main))]
-
-        ###contours_with_textline = []
-        ###for ind_tr, con_tr in enumerate(contours):
-            ###results = [cv2.pointPolygonTest(con_tr,
-            ###                                 (cx_main_textline[index_textline_con],
-            ###                                  cy_main_textline[index_textline_con]),
-            ###                                 False)
-        ###               for index_textline_con in range(len(contours_txtline_of_all_textregions)) ]
-            ###results = np.array(results)
-            ###if np.any(results==1):
-                ###contours_with_textline.append(con_tr)
-
-        textregion_index_to_del = set()
-        for index_textregion, textlines_textregion in enumerate(contours_textline):
-            if len(textlines_textregion) == 0:
-                textregion_index_to_del.add(index_textregion)
+        assert len(contours_par) == len(contours_textline)
+        indices = np.arange(len(contours_textline))
+        indices = np.delete(indices, np.flatnonzero([len(lines) == 0 for lines in contours_textline]))
         def filterfun(lis):
             if len(lis) == 0:
                 return []
-            if len(textregion_index_to_del) == 0:
-                return lis
-            return list(np.delete(lis, list(textregion_index_to_del)))
+            return list(np.array(lis)[indices])
 
         return (filterfun(contours),
                 filterfun(text_con_org),
                 filterfun(conf_contours_textregions),
                 filterfun(contours_textline),
                 filterfun(contours_only_text_parent_d_ordered),
-                np.arange(len(contours) - len(textregion_index_to_del)))
+                indices
+        )
 
-    def delete_regions_without_textlines(
-            self, slopes, all_found_textline_polygons, boxes_text, txt_con_org,
-            contours_only_text_parent, index_by_text_par_con):
-
-        slopes_rem = []
-        all_found_textline_polygons_rem = []
-        boxes_text_rem = []
-        txt_con_org_rem = []
-        contours_only_text_parent_rem = []
-        index_by_text_par_con_rem = []
-
-        for i, ind_con in enumerate(all_found_textline_polygons):
-            if len(ind_con):
-                all_found_textline_polygons_rem.append(ind_con)
-                slopes_rem.append(slopes[i])
-                boxes_text_rem.append(boxes_text[i])
-                txt_con_org_rem.append(txt_con_org[i])
-                contours_only_text_parent_rem.append(contours_only_text_parent[i])
-                index_by_text_par_con_rem.append(index_by_text_par_con[i])
-
-        index_sort = np.argsort(index_by_text_par_con_rem)
-        indexes_new = np.array(range(len(index_by_text_par_con_rem)))
-
-        index_by_text_par_con_rem_sort = [indexes_new[index_sort==j][0]
-                                          for j in range(len(index_by_text_par_con_rem))]
-
-        return (slopes_rem, all_found_textline_polygons_rem, boxes_text_rem, txt_con_org_rem,
-                contours_only_text_parent_rem, index_by_text_par_con_rem_sort)
-    
     def separate_marginals_to_left_and_right_and_order_from_top_to_down(
             self, polygons_of_marginals, all_found_textline_polygons_marginals, all_box_coord_marginals,
             slopes_marginals, mid_point_of_page_width):
@@ -4679,15 +4623,6 @@ class Eynollah:
                             polygons_of_marginals, polygons_of_marginals, textline_mask_tot_ea_org,
                             boxes_marginals, slope_deskew)
 
-                    #slopes, all_found_textline_polygons, boxes_text, txt_con_org, \
-                    #    contours_only_text_parent, index_by_text_par_con = \
-                    #    self.delete_regions_without_textlines(slopes, all_found_textline_polygons,
-                    #        boxes_text, txt_con_org, contours_only_text_parent, index_by_text_par_con)
-                    #slopes_marginals, all_found_textline_polygons_marginals, boxes_marginals, \
-                    #    polygons_of_marginals, polygons_of_marginals, _ = \
-                    #    self.delete_regions_without_textlines(slopes_marginals, all_found_textline_polygons_marginals,
-                    #        boxes_marginals, polygons_of_marginals, polygons_of_marginals,
-                    #        np.array(range(len(polygons_of_marginals))))
                     all_found_textline_polygons = dilate_textline_contours(
                         all_found_textline_polygons)
                     all_found_textline_polygons = self.filter_contours_inside_a_bigger_one(

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -2567,26 +2567,25 @@ class Eynollah:
             ref_point = 0
             order_of_texts_tot = []
             id_of_texts_tot = []
-            for iij in range(len(boxes)):
-                ys = slice(*boxes[iij][2:4])
-                xs = slice(*boxes[iij][0:2])
+            for iij, box in enumerate(boxes):
+                ys = slice(*box[2:4])
+                xs = slice(*box[0:2])
                 args_contours_box = args_contours[np.array(arg_text_con) == iij]
                 args_contours_box_h = args_contours_h[np.array(arg_text_con_h) == iij]
                 con_inter_box = contours_only_text_parent[args_contours_box]
                 con_inter_box_h = contours_only_text_parent_h[args_contours_box_h]
 
-
-                indexes_sorted, matrix_of_orders, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
-                    textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, boxes[iij][2])
+                indexes_sorted, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
+                    textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, box[2])
 
                 order_of_texts, id_of_texts = order_and_id_of_texts(
                     con_inter_box, con_inter_box_h,
-                    matrix_of_orders, indexes_sorted, index_by_kind_sorted, kind_of_texts_sorted, ref_point)
+                    indexes_sorted, index_by_kind_sorted, kind_of_texts_sorted, ref_point)
 
-                indexes_sorted_main = np.array(indexes_sorted)[np.array(kind_of_texts_sorted) == 1]
-                indexes_by_type_main = np.array(index_by_kind_sorted)[np.array(kind_of_texts_sorted) == 1]
-                indexes_sorted_head = np.array(indexes_sorted)[np.array(kind_of_texts_sorted) == 2]
-                indexes_by_type_head = np.array(index_by_kind_sorted)[np.array(kind_of_texts_sorted) == 2]
+                indexes_sorted_main = indexes_sorted[kind_of_texts_sorted == 1]
+                indexes_by_type_main = index_by_kind_sorted[kind_of_texts_sorted == 1]
+                indexes_sorted_head = indexes_sorted[kind_of_texts_sorted == 2]
+                indexes_by_type_head = index_by_kind_sorted[kind_of_texts_sorted == 2]
 
                 for zahler, _ in enumerate(args_contours_box):
                     arg_order_v = indexes_sorted_main[zahler]
@@ -2664,25 +2663,25 @@ class Eynollah:
             ref_point = 0
             order_of_texts_tot = []
             id_of_texts_tot = []
-            for iij, _ in enumerate(boxes):
-                ys = slice(*boxes[iij][2:4])
-                xs = slice(*boxes[iij][0:2])
+            for iij, box in enumerate(boxes):
+                ys = slice(*box[2:4])
+                xs = slice(*box[0:2])
                 args_contours_box = args_contours[np.array(arg_text_con) == iij]
                 args_contours_box_h = args_contours_h[np.array(arg_text_con_h) == iij]
                 con_inter_box = contours_only_text_parent[args_contours_box]
                 con_inter_box_h = contours_only_text_parent_h[args_contours_box_h]
 
-                indexes_sorted, matrix_of_orders, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
-                    textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, boxes[iij][2])
+                indexes_sorted, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
+                    textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, box[2])
 
                 order_of_texts, id_of_texts = order_and_id_of_texts(
                     con_inter_box, con_inter_box_h,
-                    matrix_of_orders, indexes_sorted, index_by_kind_sorted, kind_of_texts_sorted, ref_point)
+                    indexes_sorted, index_by_kind_sorted, kind_of_texts_sorted, ref_point)
 
-                indexes_sorted_main = np.array(indexes_sorted)[np.array(kind_of_texts_sorted) == 1]
-                indexes_by_type_main = np.array(index_by_kind_sorted)[np.array(kind_of_texts_sorted) == 1]
-                indexes_sorted_head = np.array(indexes_sorted)[np.array(kind_of_texts_sorted) == 2]
-                indexes_by_type_head = np.array(index_by_kind_sorted)[np.array(kind_of_texts_sorted) == 2]
+                indexes_sorted_main = indexes_sorted[kind_of_texts_sorted == 1]
+                indexes_by_type_main = index_by_kind_sorted[kind_of_texts_sorted == 1]
+                indexes_sorted_head = indexes_sorted[kind_of_texts_sorted == 2]
+                indexes_by_type_head = index_by_kind_sorted[kind_of_texts_sorted == 2]
 
                 for zahler, _ in enumerate(args_contours_box):
                     arg_order_v = indexes_sorted_main[zahler]
@@ -2747,22 +2746,22 @@ class Eynollah:
             ref_point = 0
             order_of_texts_tot = []
             id_of_texts_tot = []
-            for iij in range(len(boxes)):
-                ys = slice(*boxes[iij][2:4])
-                xs = slice(*boxes[iij][0:2])
+            for iij, box in enumerate(boxes):
+                ys = slice(*box[2:4])
+                xs = slice(*box[0:2])
                 args_contours_box = args_contours[np.array(arg_text_con) == iij]
                 con_inter_box = contours_only_text_parent[args_contours_box]
                 con_inter_box_h = []
 
-                indexes_sorted, matrix_of_orders, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
-                    textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, boxes[iij][2])
+                indexes_sorted, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
+                    textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, box[2])
 
                 order_of_texts, id_of_texts = order_and_id_of_texts(
                     con_inter_box, con_inter_box_h,
-                    matrix_of_orders, indexes_sorted, index_by_kind_sorted, kind_of_texts_sorted, ref_point)
+                    indexes_sorted, index_by_kind_sorted, kind_of_texts_sorted, ref_point)
 
-                indexes_sorted_main = np.array(indexes_sorted)[np.array(kind_of_texts_sorted) == 1]
-                indexes_by_type_main = np.array(index_by_kind_sorted)[np.array(kind_of_texts_sorted) == 1]
+                indexes_sorted_main = indexes_sorted[kind_of_texts_sorted == 1]
+                indexes_by_type_main = index_by_kind_sorted[kind_of_texts_sorted == 1]
 
                 for zahler, _ in enumerate(args_contours_box):
                     arg_order_v = indexes_sorted_main[zahler]
@@ -2808,24 +2807,24 @@ class Eynollah:
             ref_point = 0
             order_of_texts_tot = []
             id_of_texts_tot = []
-            for iij in range(len(boxes)):
-                ys = slice(*boxes[iij][2:4])
-                xs = slice(*boxes[iij][0:2])
+            for iij, box in enumerate(boxes):
+                ys = slice(*box[2:4])
+                xs = slice(*box[0:2])
                 args_contours_box = args_contours[np.array(arg_text_con) == iij]
                 con_inter_box = []
                 con_inter_box_h = []
                 for i in range(len(args_contours_box)):
                     con_inter_box.append(contours_only_text_parent[args_contours_box[i]])
 
-                indexes_sorted, matrix_of_orders, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
-                    textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, boxes[iij][2])
+                indexes_sorted, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
+                    textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, box[2])
 
                 order_of_texts, id_of_texts = order_and_id_of_texts(
                     con_inter_box, con_inter_box_h,
-                    matrix_of_orders, indexes_sorted, index_by_kind_sorted, kind_of_texts_sorted, ref_point)
+                    indexes_sorted, index_by_kind_sorted, kind_of_texts_sorted, ref_point)
 
-                indexes_sorted_main = np.array(indexes_sorted)[np.array(kind_of_texts_sorted) == 1]
-                indexes_by_type_main = np.array(index_by_kind_sorted)[np.array(kind_of_texts_sorted) == 1]
+                indexes_sorted_main = indexes_sorted[kind_of_texts_sorted == 1]
+                indexes_by_type_main = index_by_kind_sorted[kind_of_texts_sorted == 1]
 
                 for zahler, _ in enumerate(args_contours_box):
                     arg_order_v = indexes_sorted_main[zahler]

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4568,7 +4568,6 @@ class Eynollah:
 
             centers = np.stack(find_center_of_contours(contours_only_text_parent)) # [2, N]
 
-            contour0 = contours_only_text_parent[-1]
             center0 = centers[:, -1:] # [2, 1]
 
             if np.abs(slope_deskew) >= SLOPE_THRESHOLD:
@@ -4578,6 +4577,9 @@ class Eynollah:
                 areas_cnt_text_d = np.array([cv2.contourArea(c) for c in contours_only_text_parent_d])
                 areas_cnt_text_d = areas_cnt_text_d / float(text_only_d.shape[0] * text_only_d.shape[1])
 
+                contours_only_text_parent_d = np.array(contours_only_text_parent_d)[areas_cnt_text_d > MIN_AREA_REGION]
+                areas_cnt_text_d = areas_cnt_text_d[areas_cnt_text_d > MIN_AREA_REGION]
+
                 if len(contours_only_text_parent_d):
                     index_con_parents_d = np.argsort(areas_cnt_text_d)
                     contours_only_text_parent_d = np.array(contours_only_text_parent_d)[index_con_parents_d]
@@ -4585,9 +4587,10 @@ class Eynollah:
 
                     centers_d = np.stack(find_center_of_contours(contours_only_text_parent_d)) # [2, N]
 
-                    contour0_d = contours_only_text_parent_d[-1]
                     center0_d = centers_d[:, -1:] # [2, 1]
 
+                    # find the largest among the largest 5 deskewed contours
+                    # that is also closest to the largest original contour
                     last5_centers_d = centers_d[:, -5:]
                     dists_d = np.linalg.norm(center0 - last5_centers_d, axis=0)
                     ind_largest = len(contours_only_text_parent_d) - last5_centers_d.shape[1] + np.argmin(dists_d)
@@ -4762,14 +4765,7 @@ class Eynollah:
             if np.abs(slope_deskew) >= SLOPE_THRESHOLD:
                 contours_only_text_parent_d_ordered = self.return_list_of_contours_with_desired_order(
                     contours_only_text_parent_d_ordered, index_by_text_par_con)
-                #try:
-                    #contours_only_text_parent_d_ordered = \
-                        #list(np.array(contours_only_text_parent_d_ordered, dtype=np.int32)[index_by_text_par_con])
-                #except:
-                    #contours_only_text_parent_d_ordered = \
-                        #list(np.array(contours_only_text_parent_d_ordered, dtype=object)[index_by_text_par_con])
             else:
-                #takes long timee
                 contours_only_text_parent_d_ordered = None
             if self.light_version:
                 fun = check_any_text_region_in_model_one_is_main_or_header_light
@@ -4949,12 +4945,6 @@ class Eynollah:
             else:
                 contours_only_text_parent_d_ordered = self.return_list_of_contours_with_desired_order(
                     contours_only_text_parent_d_ordered, index_by_text_par_con)
-                #try:
-                    #contours_only_text_parent_d_ordered = \
-                        #list(np.array(contours_only_text_parent_d_ordered, dtype=object)[index_by_text_par_con])
-                #except:
-                    #contours_only_text_parent_d_ordered = \
-                        #list(np.array(contours_only_text_parent_d_ordered, dtype=np.int32)[index_by_text_par_con])
                 order_text_new, id_of_texts_tot = self.do_order_of_regions(
                     contours_only_text_parent_d_ordered, contours_only_text_parent_h, boxes_d, textline_mask_tot_d)
 

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4265,8 +4265,8 @@ class Eynollah:
             if self.ocr and not self.tr:
                 gc.collect()
                 ocr_all_textlines = return_rnn_cnn_ocr_of_given_textlines(
-                    image_page, all_found_textline_polygons, self.prediction_model,
-                    self.b_s_ocr, self.num_to_char, textline_light=True)
+                    image_page, all_found_textline_polygons, np.zeros((len(all_found_textline_polygons), 4)),
+                    self.prediction_model, self.b_s_ocr, self.num_to_char, textline_light=True)
             else:
                 ocr_all_textlines = None
             
@@ -4756,36 +4756,36 @@ class Eynollah:
 
                 if len(all_found_textline_polygons)>0:
                     ocr_all_textlines = return_rnn_cnn_ocr_of_given_textlines(
-                        image_page, all_found_textline_polygons, self.prediction_model,
-                        self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
+                        image_page, all_found_textline_polygons, all_box_coord,
+                        self.prediction_model, self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
                 else:
                     ocr_all_textlines = None
                     
                 if all_found_textline_polygons_marginals_left and len(all_found_textline_polygons_marginals_left)>0:
                     ocr_all_textlines_marginals_left = return_rnn_cnn_ocr_of_given_textlines(
-                        image_page, all_found_textline_polygons_marginals_left, self.prediction_model,
-                        self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
+                        image_page, all_found_textline_polygons_marginals_left, all_box_coord_marginals_left,
+                        self.prediction_model, self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
                 else:
                     ocr_all_textlines_marginals_left = None
                     
                 if all_found_textline_polygons_marginals_right and len(all_found_textline_polygons_marginals_right)>0:
                     ocr_all_textlines_marginals_right = return_rnn_cnn_ocr_of_given_textlines(
-                        image_page, all_found_textline_polygons_marginals_right, self.prediction_model,
-                        self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
+                        image_page, all_found_textline_polygons_marginals_right, all_box_coord_marginals_right,
+                        self.prediction_model, self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
                 else:
                     ocr_all_textlines_marginals_right = None
                 
                 if all_found_textline_polygons_h and len(all_found_textline_polygons)>0:
                     ocr_all_textlines_h = return_rnn_cnn_ocr_of_given_textlines(
-                        image_page, all_found_textline_polygons_h, self.prediction_model,
-                        self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
+                        image_page, all_found_textline_polygons_h, all_box_coord_h,
+                        self.prediction_model, self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
                 else:
                     ocr_all_textlines_h = None
                     
                 if polygons_of_drop_capitals and len(polygons_of_drop_capitals)>0:
                     ocr_all_textlines_drop = return_rnn_cnn_ocr_of_given_textlines(
-                        image_page, polygons_of_drop_capitals, self.prediction_model,
-                        self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
+                        image_page, polygons_of_drop_capitals, np.zeros((len(polygons_of_drop_capitals), 4)),
+                        self.prediction_model, self.b_s_ocr, self.num_to_char, self.textline_light, self.curved_line)
                 else:
                     ocr_all_textlines_drop = None
 

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -2518,6 +2518,8 @@ class Eynollah:
             self, contours_only_text_parent, contours_only_text_parent_h, boxes, textline_mask_tot):
 
         self.logger.debug("enter do_order_of_regions_full_layout")
+        contours_only_text_parent = np.array(contours_only_text_parent)
+        contours_only_text_parent_h = np.array(contours_only_text_parent_h)
         boxes = np.array(boxes, dtype=int) # to be on the safe side
         cx_text_only, cy_text_only, x_min_text_only, _, _, _, y_cor_x_min_main = find_new_features_of_contours(
             contours_only_text_parent)
@@ -2573,14 +2575,9 @@ class Eynollah:
                 xs = slice(*boxes[iij][0:2])
                 args_contours_box = args_contours[np.array(arg_text_con) == iij]
                 args_contours_box_h = args_contours_h[np.array(arg_text_con_h) == iij]
-                con_inter_box = []
-                con_inter_box_h = []
+                con_inter_box = contours_only_text_parent[args_contours_box]
+                con_inter_box_h = contours_only_text_parent_h[args_contours_box_h]
 
-                for box in args_contours_box:
-                    con_inter_box.append(contours_only_text_parent[box])
-
-                for box in args_contours_box_h:
-                    con_inter_box_h.append(contours_only_text_parent_h[box])
 
                 indexes_sorted, matrix_of_orders, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
                     textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, boxes[iij][2])
@@ -2675,14 +2672,8 @@ class Eynollah:
                 xs = slice(*boxes[iij][0:2])
                 args_contours_box = args_contours[np.array(arg_text_con) == iij]
                 args_contours_box_h = args_contours_h[np.array(arg_text_con_h) == iij]
-                con_inter_box = []
-                con_inter_box_h = []
-
-                for box in args_contours_box:
-                    con_inter_box.append(contours_only_text_parent[box])
-
-                for box in args_contours_box_h:
-                    con_inter_box_h.append(contours_only_text_parent_h[box])
+                con_inter_box = contours_only_text_parent[args_contours_box]
+                con_inter_box_h = contours_only_text_parent_h[args_contours_box_h]
 
                 indexes_sorted, matrix_of_orders, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
                     textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, boxes[iij][2])
@@ -2729,6 +2720,8 @@ class Eynollah:
             self, contours_only_text_parent, contours_only_text_parent_h, boxes, textline_mask_tot):
 
         self.logger.debug("enter do_order_of_regions_no_full_layout")
+        contours_only_text_parent = np.array(contours_only_text_parent)
+        contours_only_text_parent_h = np.array(contours_only_text_parent_h)
         boxes = np.array(boxes, dtype=int) # to be on the safe side
         cx_text_only, cy_text_only, x_min_text_only, _, _, _, y_cor_x_min_main = find_new_features_of_contours(
             contours_only_text_parent)
@@ -2761,10 +2754,8 @@ class Eynollah:
                 ys = slice(*boxes[iij][2:4])
                 xs = slice(*boxes[iij][0:2])
                 args_contours_box = args_contours[np.array(arg_text_con) == iij]
-                con_inter_box = []
+                con_inter_box = contours_only_text_parent[args_contours_box]
                 con_inter_box_h = []
-                for i in range(len(args_contours_box)):
-                    con_inter_box.append(contours_only_text_parent[args_contours_box[i]])
 
                 indexes_sorted, matrix_of_orders, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
                     textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, boxes[iij][2])

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -96,6 +96,7 @@ from .utils.rotate import (
     rotation_image_new
 )
 from .utils.utils_ocr import (
+    return_start_and_end_of_common_text_of_textline_ocr_without_common_section,
     return_textline_contour_with_added_box_coordinate,
     preprocess_and_resize_image_for_ocrcnn_model,
     return_textlines_split_if_needed,
@@ -4796,7 +4797,6 @@ class Eynollah:
                     self.logger.info("Using light text line detection for OCR")
                 self.logger.info("Processing text lines...")
 
-                self.device.reset()
                 gc.collect()
 
                 torch.cuda.empty_cache()

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4068,7 +4068,9 @@ class Eynollah:
             for textregion_index_to_del in textline_in_textregion_index_to_del:
                 contours[textregion_index_to_del] = list(np.delete(
                     contours[textregion_index_to_del],
-                    textline_in_textregion_index_to_del[textregion_index_to_del]))
+                    textline_in_textregion_index_to_del[textregion_index_to_del],
+                    # needed so numpy does not flatten the entire result when 0 left
+                    axis=0))
 
             return contours
         

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -2525,22 +2525,23 @@ class Eynollah:
         cx_head, cy_head, mx_head, Mx_head, my_head, My_head, mxy_head = find_new_features_of_contours(
             contours_only_text_parent_h)
 
-        try:
+        def match_boxes(only_centers: bool):
             arg_text_con_main = np.zeros(len(contours_only_text_parent), dtype=int)
             for ii in range(len(contours_only_text_parent)):
                 check_if_textregion_located_in_a_box = False
                 for jj, box in enumerate(boxes):
-                    if (mx_main[ii] >= box[0] and
-                        Mx_main[ii] < box[1] and
-                        my_main[ii] >= box[2] and
-                        My_main[ii] < box[3]):
+                    if ((cx_main[ii] >= box[0] and
+                         cx_main[ii] < box[1] and
+                         cy_main[ii] >= box[2] and
+                         cy_main[ii] < box[3]) if only_centers else
+                        (mx_main[ii] >= box[0] and
+                         Mx_main[ii] < box[1] and
+                         my_main[ii] >= box[2] and
+                         My_main[ii] < box[3])):
                         arg_text_con_main[ii] = jj
                         check_if_textregion_located_in_a_box = True
                         break
                 if not check_if_textregion_located_in_a_box:
-                    # dists_tr_from_box = [math.sqrt((cx_main[ii] - 0.5 * box[1] - 0.5 * box[0]) ** 2 +
-                    #                                (cy_main[ii] - 0.5 * box[3] - 0.5 * box[2]) ** 2)
-                    #                      for box in boxes]
                     dists_tr_from_box = np.linalg.norm(c_boxes - np.array([[cy_main[ii]], [cx_main[ii]]]), axis=0)
                     pcontained_in_box = ((boxes[:, 2] <= cy_main[ii]) & (cy_main[ii] < boxes[:, 3]) &
                                          (boxes[:, 0] <= cx_main[ii]) & (cx_main[ii] < boxes[:, 1]))
@@ -2553,17 +2554,18 @@ class Eynollah:
             for ii in range(len(contours_only_text_parent_h)):
                 check_if_textregion_located_in_a_box = False
                 for jj, box in enumerate(boxes):
-                    if (mx_head[ii] >= box[0] and
-                        Mx_head[ii] < box[1] and
-                        my_head[ii] >= box[2] and
-                        My_head[ii] < box[3]):
+                    if ((cx_head[ii] >= box[0] and
+                         cx_head[ii] < box[1] and
+                         cy_head[ii] >= box[2] and
+                         cy_head[ii] < box[3]) if only_centers else
+                        (mx_head[ii] >= box[0] and
+                         Mx_head[ii] < box[1] and
+                         my_head[ii] >= box[2] and
+                         My_head[ii] < box[3])):
                         arg_text_con_head[ii] = jj
                         check_if_textregion_located_in_a_box = True
                         break
                 if not check_if_textregion_located_in_a_box:
-                    # dists_tr_from_box = [math.sqrt((cx_head[ii] - 0.5 * box[1] - 0.5 * box[0]) ** 2 +
-                    #                                (cy_head[ii] - 0.5 * box[3] - 0.5 * box[2]) ** 2)
-                    #                      for box in boxes]
                     dists_tr_from_box = np.linalg.norm(c_boxes - np.array([[cy_head[ii]], [cx_head[ii]]]), axis=0)
                     pcontained_in_box = ((boxes[:, 2] <= cy_head[ii]) & (cy_head[ii] < boxes[:, 3]) &
                                          (boxes[:, 0] <= cx_head[ii]) & (cx_head[ii] < boxes[:, 1]))
@@ -2613,101 +2615,16 @@ class Eynollah:
             order_of_texts_tot = np.concatenate((order_by_con_main,
                                                  order_by_con_head))
             order_text_new = np.argsort(order_of_texts_tot)
+            return order_text_new, id_of_texts_tot
 
+        try:
+            results = match_boxes(False)
         except Exception as why:
             self.logger.error(why)
-            arg_text_con_main = np.zeros(len(contours_only_text_parent), dtype=int)
-            for ii in range(len(contours_only_text_parent)):
-                check_if_textregion_located_in_a_box = False
-                for jj, box in enumerate(boxes):
-                    if (cx_main[ii] >= box[0] and
-                        cx_main[ii] < box[1] and
-                        cy_main[ii] >= box[2] and
-                        cy_main[ii] < box[3]):
-                        # this is valid if the center of region identify in which box it is located
-                        arg_text_con_main[ii] = jj
-                        check_if_textregion_located_in_a_box = True
-                        break
-                if not check_if_textregion_located_in_a_box:
-                    # dists_tr_from_box = [math.sqrt((cx_main[ii] - 0.5 * box[1] - 0.5 * box[0]) ** 2 +
-                    #                                (cy_main[ii] - 0.5 * box[3] - 0.5 * box[2]) ** 2)
-                    #                      for box in boxes]
-                    dists_tr_from_box = np.linalg.norm(c_boxes - np.array([[cy_main[ii]], [cx_main[ii]]]), axis=0)
-                    pcontained_in_box = ((boxes[:, 2] <= cy_main[ii]) & (cy_main[ii] < boxes[:, 3]) &
-                                         (boxes[:, 0] <= cx_main[ii]) & (cx_main[ii] < boxes[:, 1]))
-                    ind_min = np.argmin(np.ma.masked_array(dists_tr_from_box, ~pcontained_in_box))
-                    arg_text_con_main[ii] = ind_min
-            args_contours_main = np.arange(len(contours_only_text_parent))
-            order_by_con_main = np.zeros_like(arg_text_con_main)
-
-            arg_text_con_head = np.zeros(len(contours_only_text_parent_h), dtype=int)
-            for ii in range(len(contours_only_text_parent_h)):
-                check_if_textregion_located_in_a_box = False
-                for jj, box in enumerate(boxes):
-                    if (cx_head[ii] >= box[0] and
-                        cx_head[ii] < box[1] and
-                        cy_head[ii] >= box[2] and
-                        cy_head[ii] < box[3]):
-                        # this is valid if the center of region identify in which box it is located
-                        arg_text_con_head[ii] = jj
-                        check_if_textregion_located_in_a_box = True
-                        break
-                if not check_if_textregion_located_in_a_box:
-                    # dists_tr_from_box = [math.sqrt((cx_head[ii] - 0.5 * box[1] - 0.5 * box[0]) ** 2 +
-                    #                                (cy_head[ii] - 0.5 * box[3] - 0.5 * box[2]) ** 2)
-                    #                      for box in boxes]
-                    dists_tr_from_box = np.linalg.norm(c_boxes - np.array([[cy_head[ii]], [cx_head[ii]]]), axis=0)
-                    pcontained_in_box = ((boxes[:, 2] <= cy_head[ii]) & (cy_head[ii] < boxes[:, 3]) &
-                                         (boxes[:, 0] <= cx_head[ii]) & (cx_head[ii] < boxes[:, 1]))
-                    ind_min = np.argmin(np.ma.masked_array(dists_tr_from_box, ~pcontained_in_box))
-                    arg_text_con_head[ii] = ind_min
-            args_contours_head = np.arange(len(contours_only_text_parent_h))
-            order_by_con_head = np.zeros_like(arg_text_con_head)
-
-            ref_point = 0
-            order_of_texts_tot = []
-            id_of_texts_tot = []
-            for iij, box in enumerate(boxes):
-                ys = slice(*box[2:4])
-                xs = slice(*box[0:2])
-                args_contours_box_main = args_contours_main[arg_text_con_main == iij]
-                args_contours_box_head = args_contours_head[arg_text_con_head == iij]
-                con_inter_box = contours_only_text_parent[args_contours_box_main]
-                con_inter_box_h = contours_only_text_parent_h[args_contours_box_head]
-
-                indexes_sorted, kind_of_texts_sorted, index_by_kind_sorted = order_of_regions(
-                    textline_mask_tot[ys, xs], con_inter_box, con_inter_box_h, box[2])
-
-                order_of_texts, id_of_texts = order_and_id_of_texts(
-                    con_inter_box, con_inter_box_h,
-                    indexes_sorted, index_by_kind_sorted, kind_of_texts_sorted, ref_point)
-
-                indexes_sorted_main = indexes_sorted[kind_of_texts_sorted == 1]
-                indexes_by_type_main = index_by_kind_sorted[kind_of_texts_sorted == 1]
-                indexes_sorted_head = indexes_sorted[kind_of_texts_sorted == 2]
-                indexes_by_type_head = index_by_kind_sorted[kind_of_texts_sorted == 2]
-
-                for zahler, _ in enumerate(args_contours_box_main):
-                    arg_order_v = indexes_sorted_main[zahler]
-                    order_by_con_main[args_contours_box_main[indexes_by_type_main[zahler]]] = \
-                        np.flatnonzero(indexes_sorted == arg_order_v) + ref_point
-
-                for zahler, _ in enumerate(args_contours_box_head):
-                    arg_order_v = indexes_sorted_head[zahler]
-                    order_by_con_head[args_contours_box_head[indexes_by_type_head[zahler]]] = \
-                        np.flatnonzero(indexes_sorted == arg_order_v) + ref_point
-
-                for jji in range(len(id_of_texts)):
-                    order_of_texts_tot.append(order_of_texts[jji] + ref_point)
-                    id_of_texts_tot.append(id_of_texts[jji])
-                ref_point += len(id_of_texts)
-
-            order_of_texts_tot = np.concatenate((order_by_con_main,
-                                                 order_by_con_head))
-            order_text_new = np.argsort(order_of_texts_tot)
+            results = match_boxes(True)
 
         self.logger.debug("exit do_order_of_regions")
-        return order_text_new, id_of_texts_tot
+        return results
 
     def check_iou_of_bounding_box_and_contour_for_tables(
             self, layout, table_prediction_early, pixel_table, num_col_classifier):

--- a/src/eynollah/eynollah.py
+++ b/src/eynollah/eynollah.py
@@ -4260,18 +4260,6 @@ class Eynollah:
             order_text_new = [0]
             slopes =[0]
             id_of_texts_tot =['region_0001']
-
-            polygons_of_images = []
-            slopes_marginals_left = []
-            slopes_marginals_right = []
-            polygons_of_marginals_left = []
-            polygons_of_marginals_right = []
-            all_found_textline_polygons_marginals_left = []
-            all_found_textline_polygons_marginals_right = []
-            all_box_coord_marginals_left = []
-            all_box_coord_marginals_right = []
-            polygons_seplines = []
-            contours_tables = []
             conf_contours_textregions =[0]
             
             if self.ocr and not self.tr:
@@ -4284,15 +4272,13 @@ class Eynollah:
             
             pcgts = self.writer.build_pagexml_no_full_layout(
                 cont_page, page_coord, order_text_new, id_of_texts_tot,
-                all_found_textline_polygons, page_coord, polygons_of_images,
-                polygons_of_marginals_left, polygons_of_marginals_right,
-                all_found_textline_polygons_marginals_left, all_found_textline_polygons_marginals_right,
-                all_box_coord_marginals_left, all_box_coord_marginals_right,
-                slopes, slopes_marginals_left, slopes_marginals_right, 
-                cont_page, polygons_seplines, contours_tables,
+                all_found_textline_polygons, page_coord, [],
+                [], [], [], [], [], [],
+                slopes, [], [],
+                cont_page, [], [],
                 ocr_all_textlines=ocr_all_textlines,
                 conf_contours_textregion=conf_contours_textregions,
-                skip_layout_reading_order=self.skip_layout_and_reading_order)
+                skip_layout_reading_order=True)
             self.logger.info("Basic processing complete")
             return pcgts
 
@@ -4884,9 +4870,11 @@ class Eynollah:
                 all_found_textline_polygons_marginals_left, all_found_textline_polygons_marginals_right,
                 all_box_coord_marginals_left, all_box_coord_marginals_right,
                 slopes, slopes_marginals_left, slopes_marginals_right, 
-                cont_page, polygons_seplines, contours_tables, ocr_all_textlines,
-                ocr_all_textlines_marginals_left, ocr_all_textlines_marginals_right,
-                conf_contours_textregions)
+                cont_page, polygons_seplines, contours_tables,
+                ocr_all_textlines=ocr_all_textlines,
+                ocr_all_textlines_marginals_left=ocr_all_textlines_marginals_left,
+                ocr_all_textlines_marginals_right=ocr_all_textlines_marginals_right,
+                conf_contours_textregions=conf_contours_textregions)
             
         return pcgts
 

--- a/src/eynollah/image_enhancer.py
+++ b/src/eynollah/image_enhancer.py
@@ -6,23 +6,23 @@ from logging import Logger
 import os
 import time
 from typing import Optional
-import atexit
-from functools import partial
 from pathlib import Path
-from multiprocessing import cpu_count
 import gc
+
 import cv2
 import numpy as np
 from ocrd_utils import getLogger, tf_disable_interactive_logs
 import tensorflow as tf
 from skimage.morphology import skeletonize
 from tensorflow.keras.models import load_model
+
 from .utils.resize import resize_image
 from .utils.pil_cv2 import pil2cv
 from .utils import (
     is_image_filename,
     crop_image_inside_box
 )
+from .eynollah import PatchEncoder, Patches
 
 DPI_THRESHOLD = 298
 KERNEL = np.ones((5, 5), np.uint8)

--- a/src/eynollah/mb_ro_on_layout.py
+++ b/src/eynollah/mb_ro_on_layout.py
@@ -6,25 +6,24 @@ from logging import Logger
 import os
 import time
 from typing import Optional
-import atexit
-from functools import partial
 from pathlib import Path
-from multiprocessing import cpu_count
 import xml.etree.ElementTree as ET
+
 import cv2
 import numpy as np
 from ocrd_utils import getLogger
 import statistics
 import tensorflow as tf
 from tensorflow.keras.models import load_model
-from .utils.resize import resize_image
 
+from .utils.resize import resize_image
 from .utils.contour import (
     find_new_features_of_contours,
     return_contours_of_image,
     return_parent_contours,
 )
 from .utils import is_xml_filename
+from .eynollah import PatchEncoder, Patches
 
 DPI_THRESHOLD = 298
 KERNEL = np.ones((5, 5), np.uint8)

--- a/src/eynollah/utils/__init__.py
+++ b/src/eynollah/utils/__init__.py
@@ -1325,7 +1325,7 @@ def order_of_regions(textline_mask, contours_main, contours_header, y_ref):
             final_types.append(1)
             final_index_type.append(ind_missed)
 
-    return final_indexers_sorted, matrix_of_orders, final_types, final_index_type
+    return np.array(final_indexers_sorted), np.array(final_types), np.array(final_index_type)
 
 def combine_hor_lines_and_delete_cross_points_and_get_lines_features_back_new(
         img_p_in_ver, img_in_hor,num_col_classifier):

--- a/src/eynollah/utils/__init__.py
+++ b/src/eynollah/utils/__init__.py
@@ -938,7 +938,7 @@ def check_any_text_region_in_model_one_is_main_or_header(
         if (pixels_header>=pixels_main) and ( (length_con[ii]/float(height_con[ii]) )>=1.3 ):
             regions_model_1[:,:][(regions_model_1[:,:]==1) & (img == 255) ]=2
             contours_only_text_parent_head.append(con)
-            if contours_only_text_parent_d_ordered is not None:
+            if len(contours_only_text_parent_d_ordered):
                 contours_only_text_parent_head_d.append(contours_only_text_parent_d_ordered[ii])
             all_box_coord_head.append(all_box_coord[ii])
             slopes_head.append(slopes[ii])
@@ -948,7 +948,7 @@ def check_any_text_region_in_model_one_is_main_or_header(
             regions_model_1[:,:][(regions_model_1[:,:]==1) & (img == 255) ]=1
             contours_only_text_parent_main.append(con)
             conf_contours_main.append(conf_contours[ii])
-            if contours_only_text_parent_d_ordered is not None:
+            if len(contours_only_text_parent_d_ordered):
                 contours_only_text_parent_main_d.append(contours_only_text_parent_d_ordered[ii])
             all_box_coord_main.append(all_box_coord[ii])
             slopes_main.append(slopes[ii])
@@ -1033,7 +1033,7 @@ def check_any_text_region_in_model_one_is_main_or_header_light(
             regions_model_1[:,:][(regions_model_1[:,:]==1) & (img == 255) ] = 2
             contours_only_text_parent_head.append(contours_only_text_parent[ii])
             conf_contours_head.append(None) # why not conf_contours[ii], too?
-            if contours_only_text_parent_d_ordered is not None:
+            if len(contours_only_text_parent_d_ordered):
                 contours_only_text_parent_head_d.append(contours_only_text_parent_d_ordered[ii])
             all_box_coord_head.append(all_box_coord[ii])
             slopes_head.append(slopes[ii])
@@ -1043,7 +1043,7 @@ def check_any_text_region_in_model_one_is_main_or_header_light(
             regions_model_1[:,:][(regions_model_1[:,:]==1) & (img == 255) ] = 1
             contours_only_text_parent_main.append(contours_only_text_parent[ii])
             conf_contours_main.append(conf_contours[ii])
-            if contours_only_text_parent_d_ordered is not None:
+            if len(contours_only_text_parent_d_ordered):
                 contours_only_text_parent_main_d.append(contours_only_text_parent_d_ordered[ii])
             all_box_coord_main.append(all_box_coord[ii])
             slopes_main.append(slopes[ii])

--- a/src/eynollah/utils/__init__.py
+++ b/src/eynollah/utils/__init__.py
@@ -1222,6 +1222,8 @@ def order_of_regions(textline_mask, contours_main, contours_head, y_ref):
     # offset from bbox of mask
     peaks_neg_new += y_ref
 
+    # assert not len(cy_main) or np.min(peaks_neg_new) <= np.min(cy_main) and np.max(cy_main) <= np.max(peaks_neg_new)
+    # assert not len(cy_head) or np.min(peaks_neg_new) <= np.min(cy_head) and np.max(cy_head) <= np.max(peaks_neg_new)
 
     matrix_of_orders = np.zeros((len(contours_main) + len(contours_head), 5), dtype=int)
     matrix_of_orders[:, 0] = np.arange(len(contours_main) + len(contours_head))
@@ -1251,16 +1253,8 @@ def order_of_regions(textline_mask, contours_main, contours_head, y_ref):
 
     ##matrix_of_orders[:len_main,4]=final_indexers_sorted[:]
 
-    # This fix is applied if the sum of the lengths of contours and contours_h
-    # does not match final_indexers_sorted. However, this is not the optimal solution..
-    if len(cy_main) + len(cy_header) == len(final_index_type):
-        pass
-    else:
-        indexes_missed = set(np.arange(len(cy_main) + len(cy_header))) - set(final_indexers_sorted)
-        for ind_missed in indexes_missed:
-            final_indexers_sorted.append(ind_missed)
-            final_types.append(1)
-            final_index_type.append(ind_missed)
+    # assert len(final_indexers_sorted) == len(contours_main) + len(contours_head)
+    # assert not len(final_indexers_sorted) or max(final_index_type) == max(len(contours_main)
 
     return np.array(final_indexers_sorted), np.array(final_types), np.array(final_index_type)
 

--- a/src/eynollah/utils/__init__.py
+++ b/src/eynollah/utils/__init__.py
@@ -1417,7 +1417,7 @@ def combine_hor_lines_and_delete_cross_points_and_get_lines_features_back_new(
         imgray = cv2.cvtColor(sep_ver_hor_cross, cv2.COLOR_BGR2GRAY)
         ret, thresh = cv2.threshold(imgray, 0, 255, 0)
         contours_cross,_=cv2.findContours(thresh,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
-        cx_cross,cy_cross ,_ , _, _ ,_,_=find_new_features_of_contours(contours_cross)
+        cx_cross, cy_cross = find_center_of_contours(contours_cross)
         for ii in range(len(cx_cross)):
             img_p_in[int(cy_cross[ii])-30:int(cy_cross[ii])+30,int(cx_cross[ii])+5:int(cx_cross[ii])+40,0]=0
             img_p_in[int(cy_cross[ii])-30:int(cy_cross[ii])+30,int(cx_cross[ii])-40:int(cx_cross[ii])-4,0]=0

--- a/src/eynollah/utils/contour.py
+++ b/src/eynollah/utils/contour.py
@@ -119,14 +119,11 @@ def return_parent_contours(contours, hierarchy):
 
 def return_contours_of_interested_region(region_pre_p, label, min_area=0.0002):
     # pixels of images are identified by 5
-    if len(region_pre_p.shape) == 3:
+    if region_pre_p.ndim == 3:
         cnts_images = (region_pre_p[:, :, 0] == label) * 1
     else:
         cnts_images = (region_pre_p[:, :] == label) * 1
-    cnts_images = cnts_images.astype(np.uint8)
-    cnts_images = np.repeat(cnts_images[:, :, np.newaxis], 3, axis=2)
-    imgray = cv2.cvtColor(cnts_images, cv2.COLOR_BGR2GRAY)
-    ret, thresh = cv2.threshold(imgray, 0, 255, 0)
+    _, thresh = cv2.threshold(cnts_images.astype(np.uint8), 0, 255, 0)
 
     contours_imgs, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
     contours_imgs = return_parent_contours(contours_imgs, hierarchy)
@@ -135,13 +132,11 @@ def return_contours_of_interested_region(region_pre_p, label, min_area=0.0002):
     return contours_imgs
 
 def do_work_of_contours_in_image(contour, index_r_con, img, slope_first):
-    img_copy = np.zeros(img.shape)
-    img_copy = cv2.fillPoly(img_copy, pts=[contour], color=(1, 1, 1))
+    img_copy = np.zeros(img.shape[:2], dtype=np.uint8)
+    img_copy = cv2.fillPoly(img_copy, pts=[contour], color=1)
 
     img_copy = rotation_image_new(img_copy, -slope_first)
-    img_copy = img_copy.astype(np.uint8)
-    imgray = cv2.cvtColor(img_copy, cv2.COLOR_BGR2GRAY)
-    ret, thresh = cv2.threshold(imgray, 0, 255, 0)
+    _, thresh = cv2.threshold(img_copy, 0, 255, 0)
 
     cont_int, _ = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
 
@@ -164,8 +159,8 @@ def get_textregion_contours_in_org_image(cnts, img, slope_first):
     cnts_org = []
     # print(cnts,'cnts')
     for i in range(len(cnts)):
-        img_copy = np.zeros(img.shape)
-        img_copy = cv2.fillPoly(img_copy, pts=[cnts[i]], color=(1, 1, 1))
+        img_copy = np.zeros(img.shape[:2], dtype=np.uint8)
+        img_copy = cv2.fillPoly(img_copy, pts=[cnts[i]], color=1)
 
         # plt.imshow(img_copy)
         # plt.show()
@@ -176,9 +171,7 @@ def get_textregion_contours_in_org_image(cnts, img, slope_first):
         # plt.imshow(img_copy)
         # plt.show()
 
-        img_copy = img_copy.astype(np.uint8)
-        imgray = cv2.cvtColor(img_copy, cv2.COLOR_BGR2GRAY)
-        ret, thresh = cv2.threshold(imgray, 0, 255, 0)
+        _, thresh = cv2.threshold(img_copy, 0, 255, 0)
 
         cont_int, _ = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
         cont_int[0][:, 0, 0] = cont_int[0][:, 0, 0] + np.abs(img_copy.shape[1] - img.shape[1])
@@ -195,12 +188,11 @@ def get_textregion_contours_in_org_image_light_old(cnts, img, slope_first):
                      interpolation=cv2.INTER_NEAREST)
     cnts_org = []
     for cnt in cnts:
-        img_copy = np.zeros(img.shape)
-        img_copy = cv2.fillPoly(img_copy, pts=[(cnt / zoom).astype(int)], color=(1, 1, 1))
+        img_copy = np.zeros(img.shape[:2], dtype=np.uint8)
+        img_copy = cv2.fillPoly(img_copy, pts=[cnt // zoom], color=1)
 
         img_copy = rotation_image_new(img_copy, -slope_first).astype(np.uint8)
-        imgray = cv2.cvtColor(img_copy, cv2.COLOR_BGR2GRAY)
-        ret, thresh = cv2.threshold(imgray, 0, 255, 0)
+        _, thresh = cv2.threshold(img_copy, 0, 255, 0)
 
         cont_int, _ = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
         cont_int[0][:, 0, 0] = cont_int[0][:, 0, 0] + np.abs(img_copy.shape[1] - img.shape[1])
@@ -210,14 +202,13 @@ def get_textregion_contours_in_org_image_light_old(cnts, img, slope_first):
     return cnts_org
 
 def do_back_rotation_and_get_cnt_back(contour_par, index_r_con, img, slope_first, confidence_matrix):
-    img_copy = np.zeros(img.shape)
-    img_copy = cv2.fillPoly(img_copy, pts=[contour_par], color=(1, 1, 1))
-    confidence_matrix_mapped_with_contour = confidence_matrix * img_copy[:,:,0]
-    confidence_contour = np.sum(confidence_matrix_mapped_with_contour) / float(np.sum(img_copy[:,:,0]))
+    img_copy = np.zeros(img.shape[:2], dtype=np.uint8)
+    img_copy = cv2.fillPoly(img_copy, pts=[contour_par], color=1)
+    confidence_matrix_mapped_with_contour = confidence_matrix * img_copy
+    confidence_contour = np.sum(confidence_matrix_mapped_with_contour) / float(np.sum(img_copy))
 
     img_copy = rotation_image_new(img_copy, -slope_first).astype(np.uint8)
-    imgray = cv2.cvtColor(img_copy, cv2.COLOR_BGR2GRAY)
-    ret, thresh = cv2.threshold(imgray, 0, 255, 0)
+    _, thresh = cv2.threshold(img_copy, 0, 255, 0)
 
     cont_int, _ = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
     if len(cont_int)==0:
@@ -245,14 +236,11 @@ def get_textregion_contours_in_org_image_light(cnts, img, confidence_matrix):
 
 def return_contours_of_interested_textline(region_pre_p, label):
     # pixels of images are identified by 5
-    if len(region_pre_p.shape) == 3:
+    if region_pre_p.ndim == 3:
         cnts_images = (region_pre_p[:, :, 0] == label) * 1
     else:
         cnts_images = (region_pre_p[:, :] == label) * 1
-    cnts_images = cnts_images.astype(np.uint8)
-    cnts_images = np.repeat(cnts_images[:, :, np.newaxis], 3, axis=2)
-    imgray = cv2.cvtColor(cnts_images, cv2.COLOR_BGR2GRAY)
-    ret, thresh = cv2.threshold(imgray, 0, 255, 0)
+    _, thresh = cv2.threshold(cnts_images.astype(np.uint8), 0, 255, 0)
     contours_imgs, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
 
     contours_imgs = return_parent_contours(contours_imgs, hierarchy)
@@ -262,25 +250,22 @@ def return_contours_of_interested_textline(region_pre_p, label):
 
 def return_contours_of_image(image):
     if len(image.shape) == 2:
-        image = np.repeat(image[:, :, np.newaxis], 3, axis=2)
         image = image.astype(np.uint8)
+        imgray = image
     else:
         image = image.astype(np.uint8)
-    imgray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-    ret, thresh = cv2.threshold(imgray, 0, 255, 0)
+        imgray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    _, thresh = cv2.threshold(imgray, 0, 255, 0)
     contours, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
     return contours, hierarchy
 
 def return_contours_of_interested_region_by_min_size(region_pre_p, label, min_size=0.00003):
     # pixels of images are identified by 5
-    if len(region_pre_p.shape) == 3:
+    if region_pre_p.ndim == 3:
         cnts_images = (region_pre_p[:, :, 0] == label) * 1
     else:
         cnts_images = (region_pre_p[:, :] == label) * 1
-    cnts_images = cnts_images.astype(np.uint8)
-    cnts_images = np.repeat(cnts_images[:, :, np.newaxis], 3, axis=2)
-    imgray = cv2.cvtColor(cnts_images, cv2.COLOR_BGR2GRAY)
-    ret, thresh = cv2.threshold(imgray, 0, 255, 0)
+    _, thresh = cv2.threshold(cnts_images.astype(np.uint8), 0, 255, 0)
 
     contours_imgs, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
     contours_imgs = return_parent_contours(contours_imgs, hierarchy)
@@ -291,24 +276,21 @@ def return_contours_of_interested_region_by_min_size(region_pre_p, label, min_si
 
 def return_contours_of_interested_region_by_size(region_pre_p, label, min_area, max_area):
     # pixels of images are identified by 5
-    if len(region_pre_p.shape) == 3:
+    if region_pre_p.ndim == 3:
         cnts_images = (region_pre_p[:, :, 0] == label) * 1
     else:
         cnts_images = (region_pre_p[:, :] == label) * 1
-    cnts_images = cnts_images.astype(np.uint8)
-    cnts_images = np.repeat(cnts_images[:, :, np.newaxis], 3, axis=2)
-    imgray = cv2.cvtColor(cnts_images, cv2.COLOR_BGR2GRAY)
-    ret, thresh = cv2.threshold(imgray, 0, 255, 0)
+    _, thresh = cv2.threshold(cnts_images.astype(np.uint8), 0, 255, 0)
     contours_imgs, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
 
     contours_imgs = return_parent_contours(contours_imgs, hierarchy)
     contours_imgs = filter_contours_area_of_image_tables(
         thresh, contours_imgs, hierarchy, max_area=max_area, min_area=min_area)
 
-    img_ret = np.zeros((region_pre_p.shape[0], region_pre_p.shape[1], 3))
-    img_ret = cv2.fillPoly(img_ret, pts=contours_imgs, color=(1, 1, 1))
+    img_ret = np.zeros((region_pre_p.shape[0], region_pre_p.shape[1]))
+    img_ret = cv2.fillPoly(img_ret, pts=contours_imgs, color=1)
 
-    return img_ret[:, :, 0]
+    return img_ret
 
 def dilate_textline_contours(all_found_textline_polygons):
     return [[polygon2contour(contour2polygon(contour, dilate=6))

--- a/src/eynollah/utils/contour.py
+++ b/src/eynollah/utils/contour.py
@@ -36,14 +36,8 @@ def find_contours_mean_y_diff(contours_main):
     return np.mean(np.diff(np.sort(np.array(cy_main))))
 
 def get_text_region_boxes_by_given_contours(contours):
-    boxes = []
-    contours_new = []
-    for jj in range(len(contours)):
-        box = cv2.boundingRect(contours[jj])
-        boxes.append(box)
-        contours_new.append(contours[jj])
-
-    return boxes, contours_new
+    return [cv2.boundingRect(contour)
+            for contour in contours]
 
 def filter_contours_area_of_image(image, contours, hierarchy, max_area=1.0, min_area=0.0, dilate=0):
     found_polygons_early = []

--- a/src/eynollah/utils/contour.py
+++ b/src/eynollah/utils/contour.py
@@ -253,39 +253,6 @@ def return_contours_of_image(image):
     contours, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
     return contours, hierarchy
 
-def return_contours_of_interested_region_by_min_size(region_pre_p, label, min_size=0.00003):
-    # pixels of images are identified by 5
-    if region_pre_p.ndim == 3:
-        cnts_images = (region_pre_p[:, :, 0] == label) * 1
-    else:
-        cnts_images = (region_pre_p[:, :] == label) * 1
-    _, thresh = cv2.threshold(cnts_images.astype(np.uint8), 0, 255, 0)
-
-    contours_imgs, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
-    contours_imgs = return_parent_contours(contours_imgs, hierarchy)
-    contours_imgs = filter_contours_area_of_image_tables(
-        thresh, contours_imgs, hierarchy, max_area=1, min_area=min_size)
-
-    return contours_imgs
-
-def return_contours_of_interested_region_by_size(region_pre_p, label, min_area, max_area):
-    # pixels of images are identified by 5
-    if region_pre_p.ndim == 3:
-        cnts_images = (region_pre_p[:, :, 0] == label) * 1
-    else:
-        cnts_images = (region_pre_p[:, :] == label) * 1
-    _, thresh = cv2.threshold(cnts_images.astype(np.uint8), 0, 255, 0)
-    contours_imgs, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
-
-    contours_imgs = return_parent_contours(contours_imgs, hierarchy)
-    contours_imgs = filter_contours_area_of_image_tables(
-        thresh, contours_imgs, hierarchy, max_area=max_area, min_area=min_area)
-
-    img_ret = np.zeros((region_pre_p.shape[0], region_pre_p.shape[1]))
-    img_ret = cv2.fillPoly(img_ret, pts=contours_imgs, color=1)
-
-    return img_ret
-
 def dilate_textline_contours(all_found_textline_polygons):
     return [[polygon2contour(contour2polygon(contour, dilate=6))
              for contour in region]

--- a/src/eynollah/utils/contour.py
+++ b/src/eynollah/utils/contour.py
@@ -216,7 +216,7 @@ def do_back_rotation_and_get_cnt_back(contour_par, index_r_con, img, slope_first
 
 def get_textregion_contours_in_org_image_light(cnts, img, confidence_matrix):
     if not len(cnts):
-        return [], []
+        return []
 
     confidence_matrix = cv2.resize(confidence_matrix,
                                    (img.shape[1] // 6, img.shape[0] // 6),
@@ -226,7 +226,7 @@ def get_textregion_contours_in_org_image_light(cnts, img, confidence_matrix):
         cnt_mask = np.zeros(confidence_matrix.shape)
         cnt_mask = cv2.fillPoly(cnt_mask, pts=[cnt // 6], color=1.0)
         confs.append(np.sum(confidence_matrix * cnt_mask) / np.sum(cnt_mask))
-    return cnts, confs
+    return confs
 
 def return_contours_of_interested_textline(region_pre_p, label):
     # pixels of images are identified by 5

--- a/src/eynollah/utils/drop_capitals.py
+++ b/src/eynollah/utils/drop_capitals.py
@@ -1,6 +1,7 @@
 import numpy as np
 import cv2
 from .contour import (
+    find_center_of_contours,
     find_new_features_of_contours,
     return_contours_of_image,
     return_parent_contours,
@@ -22,8 +23,8 @@ def adhere_drop_capital_region_into_corresponding_textline(
 ):
     # print(np.shape(all_found_textline_polygons),np.shape(all_found_textline_polygons[3]),'all_found_textline_polygonsshape')
     # print(all_found_textline_polygons[3])
-    cx_m, cy_m, _, _, _, _, _ = find_new_features_of_contours(contours_only_text_parent)
-    cx_h, cy_h, _, _, _, _, _ = find_new_features_of_contours(contours_only_text_parent_h)
+    cx_m, cy_m = find_center_of_contours(contours_only_text_parent)
+    cx_h, cy_h = find_center_of_contours(contours_only_text_parent_h)
     cx_d, cy_d, _, _, y_min_d, y_max_d, _ = find_new_features_of_contours(polygons_of_drop_capitals)
 
     img_con_all = np.zeros((text_regions_p.shape[0], text_regions_p.shape[1], 3))
@@ -89,9 +90,9 @@ def adhere_drop_capital_region_into_corresponding_textline(
                 region_final = region_with_intersected_drop[np.argmax(sum_pixels_of_intersection)] - 1
 
                 # print(region_final,'region_final')
-                # cx_t,cy_t ,_, _, _ ,_,_= find_new_features_of_contours(all_found_textline_polygons[int(region_final)])
+                # cx_t, cy_t = find_center_of_contours(all_found_textline_polygons[int(region_final)])
                 try:
-                    cx_t, cy_t, _, _, _, _, _ = find_new_features_of_contours(all_found_textline_polygons[int(region_final)])
+                    cx_t, cy_t = find_center_of_contours(all_found_textline_polygons[int(region_final)])
                     # print(all_box_coord[j_cont])
                     # print(cx_t)
                     # print(cy_t)
@@ -153,9 +154,9 @@ def adhere_drop_capital_region_into_corresponding_textline(
 
                 # areas_main=np.array([cv2.contourArea(all_found_textline_polygons[int(region_final)][0][j] ) for j in range(len(all_found_textline_polygons[int(region_final)]))])
 
-                # cx_t,cy_t ,_, _, _ ,_,_= find_new_features_of_contours(all_found_textline_polygons[int(region_final)])
+                # cx_t, cy_t = find_center_of_contours(all_found_textline_polygons[int(region_final)])
                 try:
-                    cx_t, cy_t, _, _, _, _, _ = find_new_features_of_contours(all_found_textline_polygons[int(region_final)])
+                    cx_t, cy_t = find_center_of_contours(all_found_textline_polygons[int(region_final)])
                     # print(all_box_coord[j_cont])
                     # print(cx_t)
                     # print(cy_t)
@@ -208,7 +209,7 @@ def adhere_drop_capital_region_into_corresponding_textline(
 
                 try:
                     # print(all_found_textline_polygons[j_cont][0])
-                    cx_t, cy_t, _, _, _, _, _ = find_new_features_of_contours(all_found_textline_polygons[int(region_final)])
+                    cx_t, cy_t = find_center_of_contours(all_found_textline_polygons[int(region_final)])
                     # print(all_box_coord[j_cont])
                     # print(cx_t)
                     # print(cy_t)
@@ -261,7 +262,7 @@ def adhere_drop_capital_region_into_corresponding_textline(
             else:
                 pass
 
-            ##cx_t,cy_t ,_, _, _ ,_,_= find_new_features_of_contours(all_found_textline_polygons[int(region_final)])
+            ##cx_t, cy_t = find_center_of_contours(all_found_textline_polygons[int(region_final)])
             ###print(all_box_coord[j_cont])
             ###print(cx_t)
             ###print(cy_t)
@@ -315,9 +316,9 @@ def adhere_drop_capital_region_into_corresponding_textline(
                 region_final = region_with_intersected_drop[np.argmax(sum_pixels_of_intersection)] - 1
 
                 # print(region_final,'region_final')
-                # cx_t,cy_t ,_, _, _ ,_,_= find_new_features_of_contours(all_found_textline_polygons[int(region_final)])
+                # cx_t, cy_t = find_center_of_contours(all_found_textline_polygons[int(region_final)])
                 try:
-                    cx_t, cy_t, _, _, _, _, _ = find_new_features_of_contours(all_found_textline_polygons[int(region_final)])
+                    cx_t, cy_t = find_center_of_contours(all_found_textline_polygons[int(region_final)])
                     # print(all_box_coord[j_cont])
                     # print(cx_t)
                     # print(cy_t)
@@ -375,12 +376,12 @@ def adhere_drop_capital_region_into_corresponding_textline(
 
                 # areas_main=np.array([cv2.contourArea(all_found_textline_polygons[int(region_final)][0][j] ) for j in range(len(all_found_textline_polygons[int(region_final)]))])
 
-                # cx_t,cy_t ,_, _, _ ,_,_= find_new_features_of_contours(all_found_textline_polygons[int(region_final)])
+                # cx_t, cy_t = find_center_of_contours(all_found_textline_polygons[int(region_final)])
 
                 # print(cx_t,'print')
                 try:
                     # print(all_found_textline_polygons[j_cont][0])
-                    cx_t, cy_t, _, _, _, _, _ = find_new_features_of_contours(all_found_textline_polygons[int(region_final)])
+                    cx_t, cy_t = find_center_of_contours(all_found_textline_polygons[int(region_final)])
                     # print(all_box_coord[j_cont])
                     # print(cx_t)
                     # print(cy_t)
@@ -453,7 +454,7 @@ def adhere_drop_capital_region_into_corresponding_textline(
     #####try:
     #####if len(contours_new_parent)==1:
     ######print(all_found_textline_polygons[j_cont][0])
-    #####cx_t,cy_t ,_, _, _ ,_,_= find_new_features_of_contours(all_found_textline_polygons[j_cont])
+    #####cx_t, cy_t = find_center_of_contours(all_found_textline_polygons[j_cont])
     ######print(all_box_coord[j_cont])
     ######print(cx_t)
     ######print(cy_t)

--- a/src/eynollah/utils/separate_lines.py
+++ b/src/eynollah/utils/separate_lines.py
@@ -1344,51 +1344,49 @@ def textline_contours_postprocessing(textline_mask, slope,
     textline_mask = cv2.morphologyEx(textline_mask, cv2.MORPH_CLOSE, kernel)
     textline_mask = cv2.erode(textline_mask, kernel, iterations=2)
     # textline_mask = cv2.erode(textline_mask, kernel, iterations=1)
-    try:
-        x_help = 30
-        y_help = 2
 
-        textline_mask_help = np.zeros((textline_mask.shape[0] + int(2 * y_help),
-                                       textline_mask.shape[1] + int(2 * x_help)))
-        textline_mask_help[y_help : y_help + textline_mask.shape[0],
-                           x_help : x_help + textline_mask.shape[1]] = np.copy(textline_mask[:, :])
+    x_help = 30
+    y_help = 2
 
-        dst = rotate_image(textline_mask_help, slope)
-        dst[dst != 0] = 1
+    textline_mask_help = np.zeros((textline_mask.shape[0] + int(2 * y_help),
+                                   textline_mask.shape[1] + int(2 * x_help)))
+    textline_mask_help[y_help : y_help + textline_mask.shape[0],
+                       x_help : x_help + textline_mask.shape[1]] = np.copy(textline_mask[:, :])
 
-        # if np.abs(slope)>.5 and textline_mask.shape[0]/float(textline_mask.shape[1])>3:
-        # plt.imshow(dst)
-        # plt.show()
+    dst = rotate_image(textline_mask_help, slope)
+    dst[dst != 0] = 1
 
-        contour_text_copy = contour_text_interest.copy()
-        contour_text_copy[:, 0, 0] = contour_text_copy[:, 0, 0] - box_ind[0]
-        contour_text_copy[:, 0, 1] = contour_text_copy[:, 0, 1] - box_ind[1]
+    # if np.abs(slope)>.5 and textline_mask.shape[0]/float(textline_mask.shape[1])>3:
+    # plt.imshow(dst)
+    # plt.show()
 
-        img_contour = np.zeros((box_ind[3], box_ind[2]))
-        img_contour = cv2.fillPoly(img_contour, pts=[contour_text_copy], color=255)
+    contour_text_copy = contour_text_interest.copy()
+    contour_text_copy[:, 0, 0] = contour_text_copy[:, 0, 0] - box_ind[0]
+    contour_text_copy[:, 0, 1] = contour_text_copy[:, 0, 1] - box_ind[1]
 
-        img_contour_help = np.zeros((img_contour.shape[0] + int(2 * y_help),
-                                     img_contour.shape[1] + int(2 * x_help)))
-        img_contour_help[y_help : y_help + img_contour.shape[0],
-                         x_help : x_help + img_contour.shape[1]] = np.copy(img_contour[:, :])
+    img_contour = np.zeros((box_ind[3], box_ind[2]))
+    img_contour = cv2.fillPoly(img_contour, pts=[contour_text_copy], color=255)
 
-        img_contour_rot = rotate_image(img_contour_help, slope)
+    img_contour_help = np.zeros((img_contour.shape[0] + int(2 * y_help),
+                                 img_contour.shape[1] + int(2 * x_help)))
+    img_contour_help[y_help : y_help + img_contour.shape[0],
+                     x_help : x_help + img_contour.shape[1]] = np.copy(img_contour[:, :])
 
-        _, threshrot = cv2.threshold(img_contour_rot, 0, 255, 0)
-        contours_text_rot, _ = cv2.findContours(threshrot.astype(np.uint8), cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+    img_contour_rot = rotate_image(img_contour_help, slope)
 
-        len_con_text_rot = [len(contours_text_rot[ib]) for ib in range(len(contours_text_rot))]
-        ind_big_con = np.argmax(len_con_text_rot)
+    _, threshrot = cv2.threshold(img_contour_rot, 0, 255, 0)
+    contours_text_rot, _ = cv2.findContours(threshrot.astype(np.uint8), cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
 
-        if abs(slope) > 45:
-            _, contours_rotated_clean = separate_lines_vertical_cont(
-                textline_mask, contours_text_rot[ind_big_con], box_ind, slope,
-                add_boxes_coor_into_textlines=add_boxes_coor_into_textlines)
-        else:
-            _, contours_rotated_clean = separate_lines(
-                dst, contours_text_rot[ind_big_con], slope, x_help, y_help)
-    except:
-        contours_rotated_clean = []
+    len_con_text_rot = [len(contours_text_rot[ib]) for ib in range(len(contours_text_rot))]
+    ind_big_con = np.argmax(len_con_text_rot)
+
+    if abs(slope) > 45:
+        _, contours_rotated_clean = separate_lines_vertical_cont(
+            textline_mask, contours_text_rot[ind_big_con], box_ind, slope,
+            add_boxes_coor_into_textlines=add_boxes_coor_into_textlines)
+    else:
+        _, contours_rotated_clean = separate_lines(
+            dst, contours_text_rot[ind_big_con], slope, x_help, y_help)
 
     return contours_rotated_clean
 

--- a/src/eynollah/utils/separate_lines.py
+++ b/src/eynollah/utils/separate_lines.py
@@ -1592,7 +1592,7 @@ def get_smallest_skew(img, sigma_des, angles, logger=None, plotter=None, map=map
 
 @wrap_ndarray_shared(kw='textline_mask_tot_ea')
 def do_work_of_slopes_new(
-        box_text, contour, contour_par, index_r_con,
+        box_text, contour, contour_par,
         textline_mask_tot_ea=None, slope_deskew=0.0,
         logger=None, MAX_SLOPE=999, KERNEL=None, plotter=None
 ):
@@ -1647,12 +1647,12 @@ def do_work_of_slopes_new(
         all_text_region_raw[mask_only_con_region == 0] = 0
         cnt_clean_rot = textline_contours_postprocessing(all_text_region_raw, slope_for_all, contour_par, box_text)
 
-    return cnt_clean_rot, box_text, contour, contour_par, crop_coor, index_r_con, slope
+    return cnt_clean_rot, crop_coor, slope
 
 @wrap_ndarray_shared(kw='textline_mask_tot_ea')
 @wrap_ndarray_shared(kw='mask_texts_only')
 def do_work_of_slopes_new_curved(
-        box_text, contour, contour_par, index_r_con,
+        box_text, contour_par,
         textline_mask_tot_ea=None, mask_texts_only=None,
         num_col=1, scale_par=1.0, slope_deskew=0.0,
         logger=None, MAX_SLOPE=999, KERNEL=None, plotter=None
@@ -1743,11 +1743,11 @@ def do_work_of_slopes_new_curved(
                                                                     slope_for_all, contour_par,
                                                                     box_text, True)
 
-    return textlines_cnt_per_region[::-1], box_text, contour, contour_par, crop_coor, index_r_con, slope
+    return textlines_cnt_per_region[::-1], crop_coor, slope
 
 @wrap_ndarray_shared(kw='textline_mask_tot_ea')
 def do_work_of_slopes_new_light(
-        box_text, contour, contour_par, index_r_con,
+        box_text, contour, contour_par,
         textline_mask_tot_ea=None, slope_deskew=0, textline_light=True,
         logger=None
 ):
@@ -1777,4 +1777,4 @@ def do_work_of_slopes_new_light(
         all_text_region_raw[mask_only_con_region == 0] = 0
         cnt_clean_rot = textline_contours_postprocessing(all_text_region_raw, slope_deskew, contour_par, box_text)
 
-    return cnt_clean_rot, box_text, contour, contour_par, crop_coor, index_r_con, slope_deskew
+    return cnt_clean_rot, crop_coor, slope_deskew

--- a/src/eynollah/utils/utils_ocr.py
+++ b/src/eynollah/utils/utils_ocr.py
@@ -1,12 +1,16 @@
+import math
+import copy
+
 import numpy as np
 import cv2
 import tensorflow as tf
 from scipy.signal import find_peaks
 from scipy.ndimage import gaussian_filter1d
-import math
 from PIL import Image, ImageDraw, ImageFont
 from Bio import pairwise2
+
 from .resize import resize_image
+
 
 def decode_batch_predictions(pred, num_to_char, max_len = 128):
     # input_len is the product of the batch size and the
@@ -370,7 +374,9 @@ def return_textline_contour_with_added_box_coordinate(textline_contour,  box_ind
     return textline_contour
 
 
-def return_rnn_cnn_ocr_of_given_textlines(image, all_found_textline_polygons,
+def return_rnn_cnn_ocr_of_given_textlines(image,
+                                          all_found_textline_polygons,
+                                          all_box_coord,
                                           prediction_model,
                                           b_s_ocr, num_to_char,
                                           textline_light=False,

--- a/src/eynollah/utils/xml.py
+++ b/src/eynollah/utils/xml.py
@@ -65,11 +65,7 @@ def xml_reading_order(page, order_of_texts, id_of_marginalia_left, id_of_margina
         og.add_RegionRefIndexed(RegionRefIndexedType(index=str(region_counter.get('region')), regionRef=id_marginal))
         region_counter.inc('region')
 
-def order_and_id_of_texts(found_polygons_text_region, found_polygons_text_region_h, matrix_of_orders, indexes_sorted, index_of_types, kind_of_texts, ref_point):
-    indexes_sorted = np.array(indexes_sorted)
-    index_of_types = np.array(index_of_types)
-    kind_of_texts = np.array(kind_of_texts)
-
+def order_and_id_of_texts(found_polygons_text_region, found_polygons_text_region_h, indexes_sorted, index_of_types, kind_of_texts, ref_point):
     id_of_texts = []
     order_of_texts = []
 

--- a/src/eynollah/utils/xml.py
+++ b/src/eynollah/utils/xml.py
@@ -57,8 +57,8 @@ def xml_reading_order(page, order_of_texts, id_of_marginalia_left, id_of_margina
         og.add_RegionRefIndexed(RegionRefIndexedType(index=str(region_counter.get('region')), regionRef=id_marginal))
         region_counter.inc('region')
         
-    for idx_textregion, _ in enumerate(order_of_texts):
-        og.add_RegionRefIndexed(RegionRefIndexedType(index=str(region_counter.get('region')), regionRef=region_counter.region_id(order_of_texts[idx_textregion] + 1)))
+    for idx_textregion in order_of_texts:
+        og.add_RegionRefIndexed(RegionRefIndexedType(index=str(region_counter.get('region')), regionRef=region_counter.region_id(idx_textregion + 1)))
         region_counter.inc('region')
         
     for id_marginal in id_of_marginalia_right:

--- a/src/eynollah/writer.py
+++ b/src/eynollah/writer.py
@@ -56,113 +56,30 @@ class EynollahXmlWriter():
             points_page_print = points_page_print + ' '
         return points_page_print[:-1]
 
-    def serialize_lines_in_marginal(self, marginal_region, all_found_textline_polygons_marginals, marginal_idx, page_coord, all_box_coord_marginals, slopes_marginals, counter, ocr_all_textlines_textregion):
-        for j in range(len(all_found_textline_polygons_marginals[marginal_idx])):
-            coords = CoordsType()
-            textline = TextLineType(id=counter.next_line_id, Coords=coords)
-            if ocr_all_textlines_textregion:
-                textline.set_TextEquiv( [ TextEquivType(Unicode=ocr_all_textlines_textregion[j]) ] )
-            marginal_region.add_TextLine(textline)
-            marginal_region.set_orientation(-slopes_marginals[marginal_idx])
-            points_co = ''
-            for l in range(len(all_found_textline_polygons_marginals[marginal_idx][j])):
-                if not (self.curved_line or self.textline_light):
-                    if len(all_found_textline_polygons_marginals[marginal_idx][j][l]) == 2:
-                        textline_x_coord = max(0, int((all_found_textline_polygons_marginals[marginal_idx][j][l][0] + all_box_coord_marginals[marginal_idx][2] + page_coord[2]) / self.scale_x) )
-                        textline_y_coord = max(0, int((all_found_textline_polygons_marginals[marginal_idx][j][l][1] + all_box_coord_marginals[marginal_idx][0] + page_coord[0]) / self.scale_y) )
-                    else:
-                        textline_x_coord = max(0, int((all_found_textline_polygons_marginals[marginal_idx][j][l][0][0] + all_box_coord_marginals[marginal_idx][2] + page_coord[2]) / self.scale_x) )
-                        textline_y_coord = max(0, int((all_found_textline_polygons_marginals[marginal_idx][j][l][0][1] + all_box_coord_marginals[marginal_idx][0] + page_coord[0]) / self.scale_y) )
-                    points_co += str(textline_x_coord)
-                    points_co += ','
-                    points_co += str(textline_y_coord)
-                if (self.curved_line or self.textline_light) and np.abs(slopes_marginals[marginal_idx]) <= 45:
-                    if len(all_found_textline_polygons_marginals[marginal_idx][j][l]) == 2:
-                        points_co += str(int((all_found_textline_polygons_marginals[marginal_idx][j][l][0] + page_coord[2]) / self.scale_x))
-                        points_co += ','
-                        points_co += str(int((all_found_textline_polygons_marginals[marginal_idx][j][l][1] + page_coord[0]) / self.scale_y))
-                    else:
-                        points_co += str(int((all_found_textline_polygons_marginals[marginal_idx][j][l][0][0] + page_coord[2]) / self.scale_x))
-                        points_co += ','
-                        points_co += str(int((all_found_textline_polygons_marginals[marginal_idx][j][l][0][1] + page_coord[0]) / self.scale_y))
-
-                elif (self.curved_line or self.textline_light) and np.abs(slopes_marginals[marginal_idx]) > 45:
-                    if len(all_found_textline_polygons_marginals[marginal_idx][j][l]) == 2:
-                        points_co += str(int((all_found_textline_polygons_marginals[marginal_idx][j][l][0] + all_box_coord_marginals[marginal_idx][2] + page_coord[2]) / self.scale_x))
-                        points_co += ','
-                        points_co += str(int((all_found_textline_polygons_marginals[marginal_idx][j][l][1] + all_box_coord_marginals[marginal_idx][0] + page_coord[0]) / self.scale_y))
-                    else:
-                        points_co += str(int((all_found_textline_polygons_marginals[marginal_idx][j][l][0][0] + all_box_coord_marginals[marginal_idx][2] + page_coord[2]) / self.scale_x))
-                        points_co += ','
-                        points_co += str(int((all_found_textline_polygons_marginals[marginal_idx][j][l][0][1] + all_box_coord_marginals[marginal_idx][0] + page_coord[0]) / self.scale_y))
-                points_co += ' '
-            coords.set_points(points_co[:-1])
-
     def serialize_lines_in_region(self, text_region, all_found_textline_polygons, region_idx, page_coord, all_box_coord, slopes, counter, ocr_all_textlines_textregion):
         self.logger.debug('enter serialize_lines_in_region')
-        for j in range(len(all_found_textline_polygons[region_idx])):
+        for j, polygon_textline in enumerate(all_found_textline_polygons[region_idx]):
             coords = CoordsType()
             textline = TextLineType(id=counter.next_line_id, Coords=coords)
             if ocr_all_textlines_textregion:
-                textline.set_TextEquiv( [ TextEquivType(Unicode=ocr_all_textlines_textregion[j]) ] )
+                # FIXME: add OCR confidence
+                textline.set_TextEquiv([TextEquivType(Unicode=ocr_all_textlines_textregion[j])])
             text_region.add_TextLine(textline)
             text_region.set_orientation(-slopes[region_idx])
             region_bboxes = all_box_coord[region_idx]
             points_co = ''
-            for idx_contour_textline, contour_textline in enumerate(all_found_textline_polygons[region_idx][j]):
-                if not (self.curved_line or self.textline_light):
-                    if len(contour_textline) == 2:
-                        textline_x_coord = max(0, int((contour_textline[0] + region_bboxes[2] + page_coord[2]) / self.scale_x))
-                        textline_y_coord = max(0, int((contour_textline[1] + region_bboxes[0] + page_coord[0]) / self.scale_y))
-                    else:
-                        textline_x_coord = max(0, int((contour_textline[0][0] + region_bboxes[2] + page_coord[2]) / self.scale_x))
-                        textline_y_coord = max(0, int((contour_textline[0][1] + region_bboxes[0] + page_coord[0]) / self.scale_y))
-                    points_co += str(textline_x_coord)
-                    points_co += ','
-                    points_co += str(textline_y_coord)
-
-                if self.textline_light or (self.curved_line and np.abs(slopes[region_idx]) <= 45):
-                    if len(contour_textline) == 2:
-                        points_co += str(int((contour_textline[0] + page_coord[2]) / self.scale_x))
-                        points_co += ','
-                        points_co += str(int((contour_textline[1] + page_coord[0]) / self.scale_y))
-                    else:
-                        points_co += str(int((contour_textline[0][0] + page_coord[2]) / self.scale_x))
-                        points_co += ','
-                        points_co += str(int((contour_textline[0][1] + page_coord[0])/self.scale_y))
-                elif self.curved_line and np.abs(slopes[region_idx]) > 45:
-                    if len(contour_textline)==2:
-                        points_co += str(int((contour_textline[0] + region_bboxes[2] + page_coord[2])/self.scale_x))
-                        points_co += ','
-                        points_co += str(int((contour_textline[1] + region_bboxes[0] + page_coord[0])/self.scale_y))
-                    else:
-                        points_co += str(int((contour_textline[0][0] + region_bboxes[2]+page_coord[2])/self.scale_x))
-                        points_co += ','
-                        points_co += str(int((contour_textline[0][1] + region_bboxes[0]+page_coord[0])/self.scale_y))
-                points_co += ' '
-            coords.set_points(points_co[:-1])
-
-    def serialize_lines_in_dropcapital(self, text_region, all_found_textline_polygons, region_idx, page_coord, all_box_coord, slopes, counter, ocr_all_textlines_textregion):
-        self.logger.debug('enter serialize_lines_in_region')
-        for j in range(1):
-            coords = CoordsType()
-            textline = TextLineType(id=counter.next_line_id, Coords=coords)
-            if ocr_all_textlines_textregion:
-                textline.set_TextEquiv( [ TextEquivType(Unicode=ocr_all_textlines_textregion[j]) ] )
-            text_region.add_TextLine(textline)
-            #region_bboxes = all_box_coord[region_idx]
-            points_co = ''
-            for idx_contour_textline, contour_textline in enumerate(all_found_textline_polygons[j]):
-                if len(contour_textline) == 2:
-                    points_co += str(int((contour_textline[0] + page_coord[2]) / self.scale_x))
-                    points_co += ','
-                    points_co += str(int((contour_textline[1] + page_coord[0]) / self.scale_y))
-                else:
-                    points_co += str(int((contour_textline[0][0] + page_coord[2]) / self.scale_x))
-                    points_co += ','
-                    points_co += str(int((contour_textline[0][1] + page_coord[0])/self.scale_y))
-
-                points_co += ' '
+            for point in polygon_textline:
+                if len(point) != 2:
+                    point = point[0]
+                point_x = point[0] + page_coord[2]
+                point_y = point[1] + page_coord[0]
+                # FIXME: or actually... not self.textline_light and not self.curved_line or np.abs(slopes[region_idx]) > 45?
+                if not self.textline_light and not (self.curved_line and np.abs(slopes[region_idx]) <= 45):
+                    point_x += region_bboxes[2]
+                    point_y += region_bboxes[0]
+                point_x = max(0, int(point_x / self.scale_x))
+                point_y = max(0, int(point_y / self.scale_y))
+                points_co += str(point_x) + ',' + str(point_y) + ' '
             coords.set_points(points_co[:-1])
 
     def write_pagexml(self, pcgts):
@@ -170,7 +87,7 @@ class EynollahXmlWriter():
         with open(self.output_filename, 'w') as f:
             f.write(to_xml(pcgts))
 
-    def build_pagexml_no_full_layout(self, found_polygons_text_region, page_coord, order_of_texts, id_of_texts, all_found_textline_polygons, all_box_coord, found_polygons_text_region_img, found_polygons_marginals_left, found_polygons_marginals_right, all_found_textline_polygons_marginals_left, all_found_textline_polygons_marginals_right, all_box_coord_marginals_left, all_box_coord_marginals_right, slopes, slopes_marginals_left, slopes_marginals_right, cont_page, polygons_lines_to_be_written_in_xml, found_polygons_tables, ocr_all_textlines=None, ocr_all_textlines_marginals_left=None, ocr_all_textlines_marginals_right=None, conf_contours_textregion=None, skip_layout_reading_order=False):
+    def build_pagexml_no_full_layout(self, found_polygons_text_region, page_coord, order_of_texts, id_of_texts, all_found_textline_polygons, all_box_coord, found_polygons_text_region_img, found_polygons_marginals_left, found_polygons_marginals_right, all_found_textline_polygons_marginals_left, all_found_textline_polygons_marginals_right, all_box_coord_marginals_left, all_box_coord_marginals_right, slopes, slopes_marginals_left, slopes_marginals_right, cont_page, polygons_seplines, found_polygons_tables, ocr_all_textlines=None, ocr_all_textlines_marginals_left=None, ocr_all_textlines_marginals_right=None, conf_contours_textregion=None, skip_layout_reading_order=False):
         self.logger.debug('enter build_pagexml_no_full_layout')
 
         # create the file structure
@@ -179,90 +96,79 @@ class EynollahXmlWriter():
         page.set_Border(BorderType(Coords=CoordsType(points=self.calculate_page_coords(cont_page))))
 
         counter = EynollahIdCounter()
-        if len(found_polygons_text_region) > 0:
+        if len(order_of_texts):
             _counter_marginals = EynollahIdCounter(region_idx=len(order_of_texts))
-            id_of_marginalia_left = [_counter_marginals.next_region_id for _ in found_polygons_marginals_left]
-            id_of_marginalia_right = [_counter_marginals.next_region_id for _ in found_polygons_marginals_right]
+            id_of_marginalia_left = [_counter_marginals.next_region_id
+                                     for _ in found_polygons_marginals_left]
+            id_of_marginalia_right = [_counter_marginals.next_region_id
+                                      for _ in found_polygons_marginals_right]
             xml_reading_order(page, order_of_texts, id_of_marginalia_left, id_of_marginalia_right)
 
-        for mm in range(len(found_polygons_text_region)):
-            textregion = TextRegionType(id=counter.next_region_id, type_='paragraph',
-                    Coords=CoordsType(points=self.calculate_polygon_coords(found_polygons_text_region[mm], page_coord, skip_layout_reading_order), conf=conf_contours_textregion[mm]),
-                    )
-            #textregion.set_conf(conf_contours_textregion[mm])
+        for mm, region_contour in enumerate(found_polygons_text_region):
+            textregion = TextRegionType(
+                id=counter.next_region_id, type_='paragraph',
+                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord,
+                                                                       skip_layout_reading_order),
+                                  conf=conf_contours_textregion[mm]),
+            )
             page.add_TextRegion(textregion)
             if ocr_all_textlines:
                 ocr_textlines = ocr_all_textlines[mm]
             else:
                 ocr_textlines = None
-            self.serialize_lines_in_region(textregion, all_found_textline_polygons, mm, page_coord, all_box_coord, slopes, counter, ocr_textlines)
+            self.serialize_lines_in_region(textregion, all_found_textline_polygons, mm, page_coord,
+                                           all_box_coord, slopes, counter, ocr_textlines)
         
-        for mm in range(len(found_polygons_marginals_left)):
-            marginal = TextRegionType(id=counter.next_region_id, type_='marginalia',
-                    Coords=CoordsType(points=self.calculate_polygon_coords(found_polygons_marginals_left[mm], page_coord)))
+        for mm, region_contour in enumerate(found_polygons_marginals_left):
+            marginal = TextRegionType(
+                id=counter.next_region_id, type_='marginalia',
+                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord))
+            )
             page.add_TextRegion(marginal)
             if ocr_all_textlines_marginals_left:
                 ocr_textlines = ocr_all_textlines_marginals_left[mm]
             else:
                 ocr_textlines = None
-                
-            #print(ocr_textlines, mm, len(all_found_textline_polygons_marginals_left[mm]) )
-            self.serialize_lines_in_marginal(marginal, all_found_textline_polygons_marginals_left, mm, page_coord, all_box_coord_marginals_left, slopes_marginals_left, counter, ocr_textlines)
+            self.serialize_lines_in_region(marginal, all_found_textline_polygons_marginals_left, mm, page_coord,
+                                           all_box_coord_marginals_left, slopes_marginals_left, counter, ocr_textlines)
             
-        for mm in range(len(found_polygons_marginals_right)):
-            marginal = TextRegionType(id=counter.next_region_id, type_='marginalia',
-                    Coords=CoordsType(points=self.calculate_polygon_coords(found_polygons_marginals_right[mm], page_coord)))
+        for mm, region_contour in enumerate(found_polygons_marginals_right):
+            marginal = TextRegionType(
+                id=counter.next_region_id, type_='marginalia',
+                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord))
+            )
             page.add_TextRegion(marginal)
             if ocr_all_textlines_marginals_right:
                 ocr_textlines = ocr_all_textlines_marginals_right[mm]
             else:
                 ocr_textlines = None
-                
-            self.serialize_lines_in_marginal(marginal, all_found_textline_polygons_marginals_right, mm, page_coord, all_box_coord_marginals_right, slopes_marginals_right, counter, ocr_textlines)
+            self.serialize_lines_in_region(marginal, all_found_textline_polygons_marginals_right, mm, page_coord,
+                                           all_box_coord_marginals_right, slopes_marginals_right, counter, ocr_textlines)
 
-        for mm in range(len(found_polygons_text_region_img)):
-            img_region = ImageRegionType(id=counter.next_region_id, Coords=CoordsType())
+        for region_contour in found_polygons_text_region_img:
+            img_region = ImageRegionType(
+                id=counter.next_region_id,
+                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord))
+            )
             page.add_ImageRegion(img_region)
-            points_co = ''
-            for lmm in range(len(found_polygons_text_region_img[mm])):
-                try:
-                    points_co += str(int((found_polygons_text_region_img[mm][lmm,0,0] + page_coord[2]) / self.scale_x))
-                    points_co += ','
-                    points_co += str(int((found_polygons_text_region_img[mm][lmm,0,1] + page_coord[0]) / self.scale_y))
-                    points_co += ' '
-                except:
 
-                    points_co +=  str(int((found_polygons_text_region_img[mm][lmm][0] + page_coord[2])/ self.scale_x  ))
-                    points_co += ','
-                    points_co += str(int((found_polygons_text_region_img[mm][lmm][1] + page_coord[0])/ self.scale_y  ))
-                    points_co += ' '
+        for region_contour in polygons_seplines:
+            sep = SeparatorRegionType(
+                id=counter.next_region_id,
+                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, [0, 0, 0, 0]))
+            )
+            page.add_SeparatorRegion(sep)
 
-            img_region.get_Coords().set_points(points_co[:-1])
-
-        for mm in range(len(polygons_lines_to_be_written_in_xml)):
-            sep_hor = SeparatorRegionType(id=counter.next_region_id, Coords=CoordsType())
-            page.add_SeparatorRegion(sep_hor)
-            points_co = ''
-            for lmm in range(len(polygons_lines_to_be_written_in_xml[mm])):
-                points_co += str(int((polygons_lines_to_be_written_in_xml[mm][lmm,0,0] ) / self.scale_x))
-                points_co += ','
-                points_co += str(int((polygons_lines_to_be_written_in_xml[mm][lmm,0,1] ) / self.scale_y))
-                points_co += ' '
-            sep_hor.get_Coords().set_points(points_co[:-1])
-        for mm in range(len(found_polygons_tables)):
-            tab_region = TableRegionType(id=counter.next_region_id, Coords=CoordsType())
-            page.add_TableRegion(tab_region)
-            points_co = ''
-            for lmm in range(len(found_polygons_tables[mm])):
-                points_co += str(int((found_polygons_tables[mm][lmm,0,0] + page_coord[2]) / self.scale_x))
-                points_co += ','
-                points_co += str(int((found_polygons_tables[mm][lmm,0,1] + page_coord[0]) / self.scale_y))
-                points_co += ' '
-            tab_region.get_Coords().set_points(points_co[:-1])
+        for region_contour in found_polygons_tables:
+            tab = TableRegionType(
+                id=counter.next_region_id,
+                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord))
+            )
+            page.add_TableRegion(tab)
 
         return pcgts
 
-    def build_pagexml_full_layout(self, found_polygons_text_region, found_polygons_text_region_h, page_coord, order_of_texts, id_of_texts, all_found_textline_polygons, all_found_textline_polygons_h, all_box_coord, all_box_coord_h, found_polygons_text_region_img, found_polygons_tables, found_polygons_drop_capitals, found_polygons_marginals_left,found_polygons_marginals_right, all_found_textline_polygons_marginals_left, all_found_textline_polygons_marginals_right, all_box_coord_marginals_left, all_box_coord_marginals_right, slopes, slopes_h, slopes_marginals_left, slopes_marginals_right, cont_page, polygons_lines_to_be_written_in_xml, ocr_all_textlines=None, ocr_all_textlines_h=None, ocr_all_textlines_marginals_left=None, ocr_all_textlines_marginals_right=None, ocr_all_textlines_drop=None, conf_contours_textregion=None, conf_contours_textregion_h=None):
+    def build_pagexml_full_layout(self, found_polygons_text_region, found_polygons_text_region_h, page_coord, order_of_texts, id_of_texts, all_found_textline_polygons, all_found_textline_polygons_h, all_box_coord, all_box_coord_h, found_polygons_text_region_img, found_polygons_tables, found_polygons_drop_capitals, found_polygons_marginals_left,found_polygons_marginals_right, all_found_textline_polygons_marginals_left, all_found_textline_polygons_marginals_right, all_box_coord_marginals_left, all_box_coord_marginals_right, slopes, slopes_h, slopes_marginals_left, slopes_marginals_right, cont_page, polygons_seplines, ocr_all_textlines=None, ocr_all_textlines_h=None, ocr_all_textlines_marginals_left=None, ocr_all_textlines_marginals_right=None, ocr_all_textlines_drop=None, conf_contours_textregion=None, conf_contours_textregion_h=None):
         self.logger.debug('enter build_pagexml_full_layout')
 
         # create the file structure
@@ -271,99 +177,112 @@ class EynollahXmlWriter():
         page.set_Border(BorderType(Coords=CoordsType(points=self.calculate_page_coords(cont_page))))
 
         counter = EynollahIdCounter()
-        _counter_marginals = EynollahIdCounter(region_idx=len(order_of_texts))
-        id_of_marginalia_left = [_counter_marginals.next_region_id for _ in found_polygons_marginals_left]
-        id_of_marginalia_right = [_counter_marginals.next_region_id for _ in found_polygons_marginals_right]
-        xml_reading_order(page, order_of_texts, id_of_marginalia_left, id_of_marginalia_right)
+        if len(order_of_texts):
+            _counter_marginals = EynollahIdCounter(region_idx=len(order_of_texts))
+            id_of_marginalia_left = [_counter_marginals.next_region_id
+                                     for _ in found_polygons_marginals_left]
+            id_of_marginalia_right = [_counter_marginals.next_region_id
+                                      for _ in found_polygons_marginals_right]
+            xml_reading_order(page, order_of_texts, id_of_marginalia_left, id_of_marginalia_right)
 
-        for mm in range(len(found_polygons_text_region)):
-            textregion = TextRegionType(id=counter.next_region_id, type_='paragraph',
-                    Coords=CoordsType(points=self.calculate_polygon_coords(found_polygons_text_region[mm], page_coord),  conf=conf_contours_textregion[mm]))
+        for mm, region_contour in enumerate(found_polygons_text_region):
+            textregion = TextRegionType(
+                id=counter.next_region_id, type_='paragraph',
+                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord),
+                                  conf=conf_contours_textregion[mm])
+            )
             page.add_TextRegion(textregion)
-
             if ocr_all_textlines:
                 ocr_textlines = ocr_all_textlines[mm]
             else:
                 ocr_textlines = None
-            self.serialize_lines_in_region(textregion, all_found_textline_polygons, mm, page_coord, all_box_coord, slopes, counter, ocr_textlines)
+            self.serialize_lines_in_region(textregion, all_found_textline_polygons, mm, page_coord,
+                                           all_box_coord, slopes, counter, ocr_textlines)
 
         self.logger.debug('len(found_polygons_text_region_h) %s', len(found_polygons_text_region_h))
-        for mm in range(len(found_polygons_text_region_h)):
-            textregion = TextRegionType(id=counter.next_region_id, type_='heading',
-                    Coords=CoordsType(points=self.calculate_polygon_coords(found_polygons_text_region_h[mm], page_coord)))
+        for mm, region_contour in enumerate(found_polygons_text_region_h):
+            textregion = TextRegionType(
+                id=counter.next_region_id, type_='heading',
+                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord))
+            )
             page.add_TextRegion(textregion)
-
             if ocr_all_textlines_h:
                 ocr_textlines = ocr_all_textlines_h[mm]
             else:
                 ocr_textlines = None
-            self.serialize_lines_in_region(textregion, all_found_textline_polygons_h, mm, page_coord, all_box_coord_h, slopes_h, counter, ocr_textlines)
+            self.serialize_lines_in_region(textregion, all_found_textline_polygons_h, mm, page_coord,
+                                           all_box_coord_h, slopes_h, counter, ocr_textlines)
 
-        for mm in range(len(found_polygons_marginals_left)):
-            marginal = TextRegionType(id=counter.next_region_id, type_='marginalia',
-                    Coords=CoordsType(points=self.calculate_polygon_coords(found_polygons_marginals_left[mm], page_coord)))
+        for mm, region_contour in enumerate(found_polygons_marginals_left):
+            marginal = TextRegionType(
+                id=counter.next_region_id, type_='marginalia',
+                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord))
+            )
             page.add_TextRegion(marginal)
             if ocr_all_textlines_marginals_left:
                 ocr_textlines = ocr_all_textlines_marginals_left[mm]
             else:
                 ocr_textlines = None
-            self.serialize_lines_in_marginal(marginal, all_found_textline_polygons_marginals_left, mm, page_coord, all_box_coord_marginals_left, slopes_marginals_left, counter, ocr_textlines)
-            
-        for mm in range(len(found_polygons_marginals_right)):
-            marginal = TextRegionType(id=counter.next_region_id, type_='marginalia',
-                    Coords=CoordsType(points=self.calculate_polygon_coords(found_polygons_marginals_right[mm], page_coord)))
+            self.serialize_lines_in_region(marginal, all_found_textline_polygons_marginals_left, mm, page_coord, all_box_coord_marginals_left, slopes_marginals_left, counter, ocr_textlines)
+
+        for mm, region_contour in enumerate(found_polygons_marginals_right):
+            marginal = TextRegionType(
+                id=counter.next_region_id, type_='marginalia',
+                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord))
+            )
             page.add_TextRegion(marginal)
             if ocr_all_textlines_marginals_right:
                 ocr_textlines = ocr_all_textlines_marginals_right[mm]
             else:
                 ocr_textlines = None
-            self.serialize_lines_in_marginal(marginal, all_found_textline_polygons_marginals_right, mm, page_coord, all_box_coord_marginals_right, slopes_marginals_right, counter, ocr_textlines)
-        
-        for mm in range(len(found_polygons_drop_capitals)):
-            dropcapital = TextRegionType(id=counter.next_region_id, type_='drop-capital',
-                    Coords=CoordsType(points=self.calculate_polygon_coords(found_polygons_drop_capitals[mm], page_coord)))
+            self.serialize_lines_in_region(marginal, all_found_textline_polygons_marginals_right, mm, page_coord,
+                                             all_box_coord_marginals_right, slopes_marginals_right, counter, ocr_textlines)
+
+        for mm, region_contour in enumerate(found_polygons_drop_capitals):
+            dropcapital = TextRegionType(
+                id=counter.next_region_id, type_='drop-capital',
+                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord))
+            )
             page.add_TextRegion(dropcapital)
-            all_box_coord_drop = None
-            slopes_drop = None
+            all_box_coord_drop = [[0, 0, 0, 0]]
+            slopes_drop = [0]
             if ocr_all_textlines_drop:
                 ocr_textlines = ocr_all_textlines_drop[mm]
             else:
                 ocr_textlines = None
-            self.serialize_lines_in_dropcapital(dropcapital, [found_polygons_drop_capitals[mm]], mm, page_coord, all_box_coord_drop, slopes_drop, counter, ocr_all_textlines_textregion=ocr_textlines)
+            self.serialize_lines_in_region(dropcapital, [[found_polygons_drop_capitals[mm]]], 0, page_coord,
+                                           all_box_coord_drop, slopes_drop, counter, ocr_textlines)
 
-        for mm in range(len(found_polygons_text_region_img)):
-            page.add_ImageRegion(ImageRegionType(id=counter.next_region_id, Coords=CoordsType(points=self.calculate_polygon_coords(found_polygons_text_region_img[mm], page_coord))))
+        for region_contour in found_polygons_text_region_img:
+            page.add_ImageRegion(
+                ImageRegionType(id=counter.next_region_id,
+                                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord))))
 
-        for mm in range(len(polygons_lines_to_be_written_in_xml)):
-            page.add_SeparatorRegion(SeparatorRegionType(id=counter.next_region_id, Coords=CoordsType(points=self.calculate_polygon_coords(polygons_lines_to_be_written_in_xml[mm], [0 , 0, 0, 0]))))
+        for region_contour in polygons_seplines:
+            page.add_SeparatorRegion(
+                SeparatorRegionType(id=counter.next_region_id,
+                                    Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, [0, 0, 0, 0]))))
 
-        for mm in range(len(found_polygons_tables)):
-            page.add_TableRegion(TableRegionType(id=counter.next_region_id, Coords=CoordsType(points=self.calculate_polygon_coords(found_polygons_tables[mm], page_coord))))
+        for region_contour in found_polygons_tables:
+            page.add_TableRegion(
+                TableRegionType(id=counter.next_region_id,
+                                Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord))))
 
         return pcgts
 
     def calculate_polygon_coords(self, contour, page_coord, skip_layout_reading_order=False):
         self.logger.debug('enter calculate_polygon_coords')
         coords = ''
-        for value_bbox in contour:
-            if skip_layout_reading_order:
-                if len(value_bbox) == 2:
-                    coords += str(int((value_bbox[0]) / self.scale_x))
-                    coords += ','
-                    coords += str(int((value_bbox[1]) / self.scale_y))
-                else:
-                    coords += str(int((value_bbox[0][0]) / self.scale_x))
-                    coords += ','
-                    coords += str(int((value_bbox[0][1]) / self.scale_y))
-            else:
-                if len(value_bbox) == 2:
-                    coords += str(int((value_bbox[0] + page_coord[2]) / self.scale_x))
-                    coords += ','
-                    coords += str(int((value_bbox[1] + page_coord[0]) / self.scale_y))
-                else:
-                    coords += str(int((value_bbox[0][0] + page_coord[2]) / self.scale_x))
-                    coords += ','
-                    coords += str(int((value_bbox[0][1] + page_coord[0]) / self.scale_y))
-            coords=coords + ' '
+        for point in contour:
+            if len(point) != 2:
+                point = point[0]
+            point_x = point[0]
+            point_y = point[1]
+            if not skip_layout_reading_order:
+                point_x += page_coord[2]
+                point_y += page_coord[0]
+            point_x = int(point_x  / self.scale_x)
+            point_y = int(point_y  / self.scale_y)
+            coords += str(point_x) + ',' + str(point_y) + ' '
         return coords[:-1]
 

--- a/src/eynollah/writer.py
+++ b/src/eynollah/writer.py
@@ -128,7 +128,7 @@ class EynollahXmlWriter():
             ocr_all_textlines=None, ocr_all_textlines_h=None,
             ocr_all_textlines_marginals_left=None, ocr_all_textlines_marginals_right=None,
             ocr_all_textlines_drop=None,
-            conf_contours_textregion=None, conf_contours_textregion_h=None,
+            conf_contours_textregions=None, conf_contours_textregions_h=None,
             skip_layout_reading_order=False):
         self.logger.debug('enter build_pagexml')
 
@@ -152,8 +152,8 @@ class EynollahXmlWriter():
                 Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord,
                                                                        skip_layout_reading_order))
             )
-            if conf_contours_textregion:
-                textregion.Coords.set_conf(conf_contours_textregion[mm])
+            if conf_contours_textregions:
+                textregion.Coords.set_conf(conf_contours_textregions[mm])
             page.add_TextRegion(textregion)
             if ocr_all_textlines:
                 ocr_textlines = ocr_all_textlines[mm]
@@ -168,8 +168,8 @@ class EynollahXmlWriter():
                 id=counter.next_region_id, type_='heading',
                 Coords=CoordsType(points=self.calculate_polygon_coords(region_contour, page_coord))
             )
-            if conf_contours_textregion_h:
-                textregion.Coords.set_conf(conf_contours_textregion_h[mm])
+            if conf_contours_textregions_h:
+                textregion.Coords.set_conf(conf_contours_textregions_h[mm])
             page.add_TextRegion(textregion)
             if ocr_all_textlines_h:
                 ocr_textlines = ocr_all_textlines_h[mm]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -17,7 +17,7 @@ from ocrd_models.constants import NAMESPACES as NS
 testdir = Path(__file__).parent.resolve()
 
 MODELS_LAYOUT = environ.get('MODELS_LAYOUT', str(testdir.joinpath('..', 'models_layout_v0_5_0').resolve()))
-MODELS_OCR = environ.get('MODELS_OCR', str(testdir.joinpath('..', 'models_ocr_v0_5_0').resolve()))
+MODELS_OCR = environ.get('MODELS_OCR', str(testdir.joinpath('..', 'models_ocr_v0_5_1').resolve()))
 MODELS_BIN = environ.get('MODELS_BIN', str(testdir.joinpath('..', 'default-2021-03-09').resolve()))
 
 @pytest.mark.parametrize(
@@ -31,6 +31,7 @@ MODELS_BIN = environ.get('MODELS_BIN', str(testdir.joinpath('..', 'default-2021-
              "--textline_light", "--light_version"],
             # -ep ...
             # -eoi ...
+            # FIXME: find out whether OCR extra was installed, otherwise skip these
             ["--do_ocr"],
             ["--do_ocr", "--light_version", "--textline_light"],
             ["--do_ocr", "--transformer_ocr"],

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -24,14 +24,18 @@ MODELS_BIN = environ.get('MODELS_BIN', str(testdir.joinpath('..', 'default-2021-
     "options",
     [
             [], # defaults
-            ["--allow_scaling", "--curved-line"],
+            #["--allow_scaling", "--curved-line"],
             ["--allow_scaling", "--curved-line", "--full-layout"],
             ["--allow_scaling", "--curved-line", "--full-layout", "--reading_order_machine_based"],
             ["--allow_scaling", "--curved-line", "--full-layout", "--reading_order_machine_based",
              "--textline_light", "--light_version"],
             # -ep ...
             # -eoi ...
-            # --do_ocr
+            ["--do_ocr"],
+            ["--do_ocr", "--light_version", "--textline_light"],
+            ["--do_ocr", "--transformer_ocr"],
+            #["--do_ocr", "--transformer_ocr", "--light_version", "--textline_light"],
+            ["--do_ocr", "--transformer_ocr", "--light_version", "--textline_light", "--full-layout"],
             # --skip_layout_and_reading_order
     ], ids=str)
 def test_run_eynollah_layout_filename(tmp_path, pytestconfig, caplog, options):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,6 +2,5 @@ def test_utils_import():
     import eynollah.utils
     import eynollah.utils.contour
     import eynollah.utils.drop_capitals
-    import eynollah.utils.drop_capitals
     import eynollah.utils.is_nan
     import eynollah.utils.rotate


### PR DESCRIPTION
@vahidrezanezhad @kba, for the 52 four-column test images you shared for benchmarking, this compares as follows:

| **version** | **wall time** | **CPU allocation** |
| --- | --- | --- |
|  [v0.5.0](https://github.com/qurator-spk/eynollah/releases/tag/v0.5.0) | 2388.5s | 253% |
| [#192](https://github.com/qurator-spk/eynollah/pull/192) | 2358.4s | 201% |
| [this PR](https://github.com/bertsky/eynollah/pull/4/commits/59a19a169df6a37e2d131aeb74daecfd684f9f8f) | 2012.5s | 222% |
| [this PR](https://github.com/bertsky/eynollah/pull/4/commits/e4ce4c593b838d739a4e9dfa9260de7b5fc9e916) | 2016.5s | 224% |

Changelog still follows – but we should first go through changes together.