### PR TITLE
Deploy versioned docker images and update transformers

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -35,7 +35,7 @@ jobs:
         password: ${{ secrets.DOCKERIO_PASSWORD }}
     - name: Build the Docker image
       # build both tags at the same time
-      run: make docker DOCKER_TAG="docker.io/ocrd/eynollah -t ghcr.io/qurator-spk/eynollah"
+      run: make docker DOCKER_TAG="docker.io/ocrd/eynollah ghcr.io/qurator-spk/eynollah"
     - name: Test the Docker image
       run: docker run --rm ocrd/eynollah ocrd-eynollah-segment -h
     - name: Push to Dockerhub

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= python3
 PIP ?= pip3
 EXTRAS ?=
 
-DOCKER_BASE_IMAGE ?= docker.io/ocrd/core-cuda-tf2:3.12.2
+DOCKER_BASE_IMAGE ?= docker.io/ocrd/core-cuda-tf2:3.12.3
 DOCKER_TAG ?= ocrd/eynollah
 DOCKER ?= docker
 WGET = wget -O

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ PYTHON ?= python3
 PIP ?= pip3
 EXTRAS ?=
 
-# DOCKER_BASE_IMAGE = artefakt.dev.sbb.berlin:5000/sbb/ocrd_core:v2.68.0
-DOCKER_BASE_IMAGE ?= docker.io/ocrd/core-cuda-tf2:latest
+DOCKER_BASE_IMAGE ?= docker.io/ocrd/core-cuda-tf2:3.12.2
 DOCKER_TAG ?= ocrd/eynollah
 DOCKER ?= docker
 WGET = wget -O
@@ -120,12 +119,19 @@ coverage:
 	$(MAKE) test PYTHON="coverage run"
 	coverage report -m
 
+# Concatenate docker image names with either the git tag describing current commit or 'latest' and
+# merge list with "-t"
+empty :=
+space := $(empty) $(empty)
+GIT_TAG := $(strip $(shell git describe --tags | grep -x "v[0-9]\+\.[0-9]\+\.[0-9]\+"))
+DOCKER_TAGS = $(subst $(space),$(space)-t$(space),$(DOCKER_TAG:%=$(if $(GIT_TAG),%:$(GIT_TAG),%:latest)))
+
 # Build docker image
 docker:
 	$(DOCKER) build \
 	--build-arg DOCKER_BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
 	--build-arg VCS_REF=$$(git rev-parse --short HEAD) \
 	--build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
-	-t $(DOCKER_TAG) .
+	-t $(DOCKER_TAGS) .
 
 .PHONY: models build install install-dev test smoke-test ocrd-test coverage docker help

--- a/requirements-ocr.txt
+++ b/requirements-ocr.txt
@@ -1,2 +1,2 @@
 torch
-transformers <= 4.30.2
+transformers >= 5


### PR DESCRIPTION
Will read git tag from current commit, if it's a `vMAJOR.MINOR.PATCH` tag, use that instead of `latest` for tagging the docker images.

We have a few warnings about insecurities in pre-`v5` transformers. Most of these are related to insecure opening of models and vectors for DOS attacks with crafted inputs. These risks seem mitigateable but it would be sensible not to require an outdated version of transformers in perpetuity. But if this breaks code, I'll stash that change for later.